### PR TITLE
Added new method: setMapType

### DIFF
--- a/android/lib/build.gradle
+++ b/android/lib/build.gradle
@@ -16,7 +16,7 @@ android {
 }
 
 dependencies {
-  compile 'com.facebook.react:react-native:0.29.2'
+  compile 'com.facebook.react:react-native:+'
   compile "com.google.android.gms:play-services-base:9.2.0"
   compile 'com.google.android.gms:play-services-maps:9.2.0'
 }

--- a/android/lib/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
+++ b/android/lib/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
@@ -31,6 +31,7 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
     private static final int ANIMATE_TO_COORDINATE = 2;
     private static final int FIT_TO_ELEMENTS = 3;
     private static final int FIT_TO_SUPPLIED_MARKERS = 4;
+    private static final int SET_MAP_TYPE = 5;
 
     private final Map<String, Integer> MAP_TYPES = MapBuilder.of(
             "standard", GoogleMap.MAP_TYPE_NORMAL,
@@ -213,6 +214,12 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
             case FIT_TO_SUPPLIED_MARKERS:
                 view.fitToSuppliedMarkers(args.getArray(0), args.getBoolean(1));
                 break;
+
+            case SET_MAP_TYPE:
+                int typeId = MAP_TYPES.get(args.getString(0));
+                view.map.setMapType(typeId);
+                break;
+
         }
     }
 
@@ -246,7 +253,8 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
                 "animateToRegion", ANIMATE_TO_REGION,
                 "animateToCoordinate", ANIMATE_TO_COORDINATE,
                 "fitToElements", FIT_TO_ELEMENTS,
-                "fitToSuppliedMarkers", FIT_TO_SUPPLIED_MARKERS
+                "fitToSuppliedMarkers", FIT_TO_SUPPLIED_MARKERS,
+                "setMapType", SET_MAP_TYPE
         );
     }
 

--- a/components/MapView.js
+++ b/components/MapView.js
@@ -401,6 +401,10 @@ var MapView = React.createClass({
     this._runCommand('fitToSuppliedMarkers', [markers, animated]);
   },
 
+  setMapType: function(mapType) {
+    this._runCommand('setMapType', [mapType]);
+  },
+
   takeSnapshot: function (width, height, region, callback) {
     if (!region) {
       region = this.props.region || this.props.initialRegion;

--- a/ios/AirMaps/AIRMap.h
+++ b/ios/AirMaps/AIRMap.h
@@ -9,7 +9,7 @@
 
 #import <MapKit/MapKit.h>
 #import <UIKit/UIKit.h>
-#import <React/RCTComponent.h>
+#import "RCTComponent.h"
 
 #import "RCTConvert+MapKit.h"
 #import "RCTComponent.h"

--- a/ios/AirMaps/AIRMapCallout.h
+++ b/ios/AirMaps/AIRMapCallout.h
@@ -4,7 +4,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "React/RCTView.h"
+#import "RCTView.h"
 
 
 @interface AIRMapCallout : RCTView

--- a/ios/AirMaps/AIRMapManager.m
+++ b/ios/AirMaps/AIRMapManager.m
@@ -110,6 +110,7 @@ RCT_CUSTOM_VIEW_PROPERTY(region, MKCoordinateRegion, AIRMap)
 
 #pragma mark exported MapView methods
 
+
 RCT_EXPORT_METHOD(animateToRegion:(nonnull NSNumber *)reactTag
         withRegion:(MKCoordinateRegion)region
         withDuration:(CGFloat)duration)
@@ -182,6 +183,20 @@ RCT_EXPORT_METHOD(fitToSuppliedMarkers:(nonnull NSNumber *)reactTag
             NSArray *filteredMarkers = [mapView.annotations filteredArrayUsingPredicate:filterMarkers];
 
             [mapView showAnnotations:filteredMarkers animated:animated];
+        }
+    }];
+}
+
+RCT_EXPORT_METHOD(setMapType:(nonnull NSNumber *)reactTag
+                  mapType:(MKMapType)mapType)
+{
+    [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+        id view = viewRegistry[reactTag];
+        if (![view isKindOfClass:[AIRMap class]]) {
+            RCTLogError(@"Invalid view returned from registry, expecting AIRMap, got: %@", view);
+        } else {
+            AIRMap *mapView = (AIRMap *)view;
+            mapView.mapType = mapType;
         }
     }];
 }


### PR DESCRIPTION
This method allows fast and efficient way to change the underlying map type. Supported map types are  'standard', 'satellite', 'hybrid', 'terrain'