### PR TITLE
Add back NativeMethodsMixin

### DIFF
--- a/components/MapCallout.js
+++ b/components/MapCallout.js
@@ -4,6 +4,7 @@ import {
   requireNativeComponent,
   StyleSheet,
 } from 'react-native';
+import NativeMethodsMixin from 'react/lib/NativeMethodsMixin';
 
 const propTypes = {
   ...View.propTypes,
@@ -23,6 +24,8 @@ class MapCallout extends React.Component {
 
 MapCallout.propTypes = propTypes;
 MapCallout.defaultProps = defaultProps;
+
+Object.assign(MapCallout.prototype, NativeMethodsMixin);
 
 const styles = StyleSheet.create({
   callout: {

--- a/components/MapCircle.js
+++ b/components/MapCircle.js
@@ -3,6 +3,7 @@ import {
   View,
   requireNativeComponent,
 } from 'react-native';
+import NativeMethodsMixin from 'react/lib/NativeMethodsMixin';
 
 const propTypes = {
   ...View.propTypes,
@@ -131,6 +132,8 @@ class MapCircle extends React.Component {
 
 MapCircle.propTypes = propTypes;
 MapCircle.defaultProps = defaultProps;
+
+Object.assign(MapCircle.prototype, NativeMethodsMixin);
 
 const AIRMapCircle = requireNativeComponent('AIRMapCircle', MapCircle);
 

--- a/components/MapMarker.js
+++ b/components/MapMarker.js
@@ -8,6 +8,7 @@ import {
   Animated,
   findNodeHandle,
 } from 'react-native';
+import NativeMethodsMixin from 'react/lib/NativeMethodsMixin';
 
 import resolveAssetSource from 'react-native/Libraries/Image/resolveAssetSource';
 
@@ -264,6 +265,8 @@ class MapMarker extends React.Component {
 MapMarker.propTypes = propTypes;
 MapMarker.defaultProps = defaultProps;
 MapMarker.viewConfig = viewConfig;
+
+Object.assign(MapMarker.prototype, NativeMethodsMixin);
 
 const styles = StyleSheet.create({
   marker: {

--- a/components/MapPolygon.js
+++ b/components/MapPolygon.js
@@ -3,6 +3,7 @@ import {
   View,
   requireNativeComponent,
 } from 'react-native';
+import NativeMethodsMixin from 'react/lib/NativeMethodsMixin';
 
 const propTypes = {
   ...View.propTypes,
@@ -136,6 +137,8 @@ class MapPolygon extends React.Component {
 
 MapPolygon.propTypes = propTypes;
 MapPolygon.defaultProps = defaultProps;
+
+Object.assign(MapPolygon.prototype, NativeMethodsMixin);
 
 const AIRMapPolygon = requireNativeComponent('AIRMapPolygon', MapPolygon);
 

--- a/components/MapPolyline.js
+++ b/components/MapPolyline.js
@@ -3,6 +3,7 @@ import {
   View,
   requireNativeComponent,
 } from 'react-native';
+import NativeMethodsMixin from 'react/lib/NativeMethodsMixin';
 
 const propTypes = {
   ...View.propTypes,
@@ -131,6 +132,8 @@ class MapPolyline extends React.Component {
 
 MapPolyline.propTypes = propTypes;
 MapPolyline.defaultProps = defaultProps;
+
+Object.assign(MapPolyline.prototype, NativeMethodsMixin);
 
 const AIRMapPolyline = requireNativeComponent('AIRMapPolyline', MapPolyline);
 

--- a/components/MapView.js
+++ b/components/MapView.js
@@ -9,6 +9,7 @@ import {
   ColorPropType,
   findNodeHandle,
 } from 'react-native';
+import NativeMethodsMixin from 'react/lib/NativeMethodsMixin';
 import MapMarker from './MapMarker';
 import MapPolyline from './MapPolyline';
 import MapPolygon from './MapPolygon';
@@ -468,6 +469,8 @@ class MapView extends React.Component {
 
 MapView.propTypes = propTypes;
 MapView.viewConfig = viewConfig;
+
+Object.assign(MapView.prototype, NativeMethodsMixin);
 
 const AIRMap = requireNativeComponent('AIRMap', MapView, {
   nativeOnly: {


### PR DESCRIPTION
I removed `NativeMethodsMixin` in #511 because the module moved in
0.32.0, which made it throw errors. I assumed we didn't need it because
none of its methods were being called, but I didn't realize that we want
to include it to that consumers of the library can use those methods.

to: @lelandrichardson 
