### PR TITLE
Fix list of examples on Android

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -29,6 +29,9 @@ import LiteMapView from './examples/LiteMapView';
 import CustomTiles from './examples/CustomTiles';
 import StaticMap from './examples/StaticMap';
 
+const IOS = Platform.OS === 'ios';
+const ANDROID = Platform.OS === 'android';
+
 function makeExampleMapper(useGoogleMaps) {
   if (useGoogleMaps) {
     return example => [
@@ -45,8 +48,7 @@ class App extends React.Component {
 
     this.state = {
       Component: null,
-      showGoogleMapsSwitch: Platform.OS === 'ios',
-      useGoogleMaps: Platform.OS === 'android',
+      useGoogleMaps: ANDROID,
     };
   }
 
@@ -89,7 +91,6 @@ class App extends React.Component {
   renderExamples(examples) {
     const {
       Component,
-      showGoogleMapsSwitch,
       useGoogleMaps,
     } = this.state;
 
@@ -103,7 +104,7 @@ class App extends React.Component {
             contentContainerStyle={styles.scrollview}
             showsVerticalScrollIndicator={false}
           >
-            {showGoogleMapsSwitch && this.renderGoogleSwitch()}
+            {IOS && this.renderGoogleSwitch()}
             {examples.map(example => this.renderExample(example))}
           </ScrollView>
         }
@@ -113,7 +114,7 @@ class App extends React.Component {
 
   render() {
     return this.renderExamples([
-    // [<component>, <component description>, <Google compatible>, <Google add'l description>]
+      // [<component>, <component description>, <Google compatible>, <Google add'l description>]
       [StaticMap, 'StaticMap', true],
       [DisplayLatLng, 'Tracking Position', true, '(incomplete)'],
       [ViewsAsMarkers, 'Arbitrary Views as Markers', true],
@@ -134,8 +135,9 @@ class App extends React.Component {
       [LiteMapView, 'Android Lite MapView'],
       [CustomTiles, 'Custom Tiles'],
     ]
-    .filter(example => example[2] || !this.state.useGoogleMaps)
-    .map(makeExampleMapper(this.state.useGoogleMaps))
+    // Filter out examples that are not yet supported for Google Maps on iOS.
+    .filter(example => ANDROID || (IOS && (example[2] || !this.state.useGoogleMaps)))
+    .map(makeExampleMapper(IOS && this.state.useGoogleMaps))
     );
   }
 }


### PR DESCRIPTION
In #548, we added Google Maps support for iOS. We changed the example
app to list examples based on whether they support Google Maps on iOS.
The logic was such that on Android it only showed the examples that are
iOS + Google Map compatible, however on Android this condition is
irrelevant, this commit changes it to show all examples on Android,
regardless.

### Before
![screen shot 2016-09-22 at 10 37 24 am](https://cloud.githubusercontent.com/assets/133937/18759275/a30bfc4a-80b0-11e6-8806-4c6184498ce3.png)

### After
![screen shot 2016-09-22 at 10 37 04 am](https://cloud.githubusercontent.com/assets/133937/18759280/a6b1fd68-80b0-11e6-8b1a-ecf6ab20b7b8.png)


to: @gilbox 