### PR TITLE
Added support for taking snapshots on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,6 @@ render() {
 ```
 
 ### Take Snapshot of map
-currently only for ios, android implementation WIP
 
 ```jsx
 getInitialState() {
@@ -341,11 +340,19 @@ getInitialState() {
 }
 
 takeSnapshot () {
-  // arguments to 'takeSnapshot' are width, height, coordinates and callback
-  this.refs.map.takeSnapshot(300, 300, this.state.coordinate, (err, snapshot) => {
-    // snapshot contains image 'uri' - full path to image and 'data' - base64 encoded image
-    this.setState({ mapSnapshot: snapshot })
-  })
+  // 'takeSnapshot' takes a config object with the
+  // following options
+  const snapshot = this.refs.map.takeSnapshot({
+    width: 300,      // optional, when omitted the view-width is used
+    height: 300,     // optional, when omitted the view-height is used
+    region: {..},    // iOS only, optional region to render
+    format: 'png',   // image formats: 'png', 'jpg' (default: 'png')
+    quality: 0.8,    // image quality: 0..1 (only relevant for jpg, default: 1)
+    result: 'file'   // result types: 'file', 'base64' (default: 'file')
+  });
+  snapshot.then((uri) => {
+    this.setState({ mapSnapshot: uri });
+  });
 }
 
 render() {

--- a/android/src/main/java/com/airbnb/android/react/maps/AirMapModule.java
+++ b/android/src/main/java/com/airbnb/android/react/maps/AirMapModule.java
@@ -1,0 +1,126 @@
+package com.airbnb.android.react.maps;
+
+import android.app.Activity;
+import android.util.DisplayMetrics;
+import android.util.Base64;
+import android.graphics.Bitmap;
+import android.net.Uri;
+import android.view.View;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.uimanager.UIManagerModule;
+import com.facebook.react.uimanager.UIBlock;
+import com.facebook.react.uimanager.NativeViewHierarchyManager;
+
+import com.google.android.gms.maps.GoogleMap;
+
+
+public class AirMapModule extends ReactContextBaseJavaModule {
+
+    public AirMapModule(ReactApplicationContext reactContext) {
+        super(reactContext);
+    }
+
+    @Override
+    public String getName() {
+        return "AirMapModule";
+    }
+
+    public Activity getActivity() {
+        return getCurrentActivity();
+    }
+
+    @ReactMethod
+    public void takeSnapshot(final int tag, final ReadableMap options, final Promise promise) {
+
+        // Parse and verity options
+        final ReactApplicationContext context = getReactApplicationContext();
+        final String format = options.hasKey("format") ? options.getString("format") : "png";
+        final Bitmap.CompressFormat compressFormat =
+            format.equals("png") ? Bitmap.CompressFormat.PNG :
+            format.equals("jpg") ? Bitmap.CompressFormat.JPEG : null;
+        if (compressFormat == null) {
+            promise.reject("AIRMap.takeSnapshot", "Unsupported image format: " + format + ". Try one of: png | jpg | jpeg");
+            return;
+        }
+        final double quality = options.hasKey("quality") ? options.getDouble("quality") : 1.0;
+        final DisplayMetrics displayMetrics = context.getResources().getDisplayMetrics();
+        final Integer width = options.hasKey("width") ? (int)(displayMetrics.density * options.getDouble("width")) : 0;
+        final Integer height = options.hasKey("height") ? (int)(displayMetrics.density * options.getDouble("height")) : 0;
+        final String result = options.hasKey("result") ? options.getString("result") : "file";
+
+        // Add UI-block so we can get a valid reference to the map-view
+        UIManagerModule uiManager = context.getNativeModule(UIManagerModule.class);
+        uiManager.addUIBlock(new UIBlock() {
+            public void execute (NativeViewHierarchyManager nvhm) {
+                AirMapView view = (AirMapView) nvhm.resolveView(tag);
+                if (view == null) {
+                    promise.reject("AirMapView not found");
+                    return;
+                }
+                if (view.map == null) {
+                    promise.reject("AirMapView.map is not valid");
+                    return;
+                }
+                view.map.snapshot(new GoogleMap.SnapshotReadyCallback() {
+                    public void onSnapshotReady(Bitmap snapshot) {
+
+                        // Convert image to requested width/height if neccesary
+                        if (snapshot != null && width != 0 && height != 0 && (width != snapshot.getWidth() || height != snapshot.getHeight())) {
+                            snapshot = Bitmap.createScaledBitmap(snapshot, width, height, true);
+                        }
+                        if (snapshot == null) {
+                            promise.reject("Failed to generate bitmap");
+                            return;
+                        }
+
+                        // Save the snapshot to disk
+                        OutputStream outputStream = null;
+                        try {
+                            if ("file".equals(result)) {
+                                File tempFile = File.createTempFile("AirMapSnapshot", "." + format, context.getCacheDir());
+                                outputStream = new FileOutputStream(tempFile);
+                                snapshot.compress(compressFormat, (int)(100.0 * quality), outputStream);
+                                outputStream.close();
+                                outputStream = null;
+                                String uri = Uri.fromFile(tempFile).toString();
+                                promise.resolve(uri);
+                            }
+                            else if ("base64".equals(result)) {
+                                outputStream = new ByteArrayOutputStream();
+                                snapshot.compress(compressFormat, (int)(100.0 * quality), outputStream);
+                                outputStream.close();
+                                outputStream = null;
+                                byte[] bytes = ((ByteArrayOutputStream) outputStream).toByteArray();
+                                String data = Base64.encodeToString(bytes, Base64.NO_WRAP);
+                                promise.resolve(data);
+                            }
+                        }
+                        catch (Exception e) {
+                            promise.reject(e);
+                        }
+                        finally {
+                            if (outputStream != null) {
+                                try {
+                                    outputStream.close();
+                                } catch (IOException e) {
+                                    e.printStackTrace();
+                                }
+                            }
+                        }
+                    }
+                });
+            }
+        });
+    }
+}

--- a/android/src/main/java/com/airbnb/android/react/maps/AirMapModule.java
+++ b/android/src/main/java/com/airbnb/android/react/maps/AirMapModule.java
@@ -24,8 +24,12 @@ import com.facebook.react.uimanager.NativeViewHierarchyManager;
 
 import com.google.android.gms.maps.GoogleMap;
 
-
 public class AirMapModule extends ReactContextBaseJavaModule {
+
+    private static final String SNAPSHOT_RESULT_FILE = "file";
+    private static final String SNAPSHOT_RESULT_BASE64 = "base64";
+    private static final String SNAPSHOT_FORMAT_PNG = "png";
+    private static final String SNAPSHOT_FORMAT_JPG = "jpg";
 
     public AirMapModule(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -47,12 +51,8 @@ public class AirMapModule extends ReactContextBaseJavaModule {
         final ReactApplicationContext context = getReactApplicationContext();
         final String format = options.hasKey("format") ? options.getString("format") : "png";
         final Bitmap.CompressFormat compressFormat =
-            format.equals("png") ? Bitmap.CompressFormat.PNG :
-            format.equals("jpg") ? Bitmap.CompressFormat.JPEG : null;
-        if (compressFormat == null) {
-            promise.reject("AIRMap.takeSnapshot", "Unsupported image format: " + format + ". Try one of: png | jpg | jpeg");
-            return;
-        }
+            format.equals(SNAPSHOT_FORMAT_PNG) ? Bitmap.CompressFormat.PNG :
+            format.equals(SNAPSHOT_FORMAT_JPG) ? Bitmap.CompressFormat.JPEG : null;
         final double quality = options.hasKey("quality") ? options.getDouble("quality") : 1.0;
         final DisplayMetrics displayMetrics = context.getResources().getDisplayMetrics();
         final Integer width = options.hasKey("width") ? (int)(displayMetrics.density * options.getDouble("width")) : 0;
@@ -87,7 +87,7 @@ public class AirMapModule extends ReactContextBaseJavaModule {
                         // Save the snapshot to disk
                         OutputStream outputStream = null;
                         try {
-                            if ("file".equals(result)) {
+                            if (result.equals(SNAPSHOT_RESULT_FILE)) {
                                 File tempFile = File.createTempFile("AirMapSnapshot", "." + format, context.getCacheDir());
                                 outputStream = new FileOutputStream(tempFile);
                                 snapshot.compress(compressFormat, (int)(100.0 * quality), outputStream);
@@ -96,7 +96,7 @@ public class AirMapModule extends ReactContextBaseJavaModule {
                                 String uri = Uri.fromFile(tempFile).toString();
                                 promise.resolve(uri);
                             }
-                            else if ("base64".equals(result)) {
+                            else if (result.equals(SNAPSHOT_RESULT_BASE64)) {
                                 outputStream = new ByteArrayOutputStream();
                                 snapshot.compress(compressFormat, (int)(100.0 * quality), outputStream);
                                 outputStream.close();

--- a/android/src/main/java/com/airbnb/android/react/maps/MapsPackage.java
+++ b/android/src/main/java/com/airbnb/android/react/maps/MapsPackage.java
@@ -21,7 +21,7 @@ public class MapsPackage implements ReactPackage {
 
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
-        return Collections.emptyList();
+        return Arrays.<NativeModule>asList(new AirMapModule(reactContext));
     }
 
     @Override

--- a/components/MapView.js
+++ b/components/MapView.js
@@ -446,8 +446,39 @@ class MapView extends React.Component {
   }
 
   takeSnapshot(width, height, region, callback) {
-    const finalRegion = region || this.props.region || this.props.initialRegion;
-    this._runCommand('takeSnapshot', [width, height, finalRegion, callback]);
+    return new Promise((resolve, reject) => {
+      let options;
+      if (typeof width === 'object') {
+        options = width;
+      }
+      else {
+        options = {
+          width: width,
+          height: height,
+          region: region || this.props.region || this.props.initialRegion
+        };
+      }
+      if (Platform.OS === 'android') {
+        NativeModules.AirMapModule.takeSnapshot(this._getHandle(), options).then((snapshot) => {
+          if (callback) callback(undefined, {uri: snapshot});
+          resolve(snapshot);
+        }, (err) => {
+          if (callback) callback(err);
+          reject(err);
+        });
+      }
+      else {
+        this._runCommand('takeSnapshot', [options.width, options.height, options.region, (err, snapshot) => {
+          if (callback) callback(err, snapshot);
+          if (err) {
+            reject(err);
+          }
+          else {
+            resolve(snapshot.uri);
+          }
+        }]);
+      }
+    });
   }
 
   _uiManagerCommand(name) {

--- a/components/MapView.js
+++ b/components/MapView.js
@@ -450,33 +450,39 @@ class MapView extends React.Component {
       let options;
       if (typeof width === 'object') {
         options = width;
-      }
-      else {
+      } else {
         options = {
-          width: width,
-          height: height,
-          region: region || this.props.region || this.props.initialRegion
+          width,
+          height,
+          region: region || this.props.region || this.props.initialRegion,
         };
       }
       if (Platform.OS === 'android') {
         NativeModules.AirMapModule.takeSnapshot(this._getHandle(), options).then((snapshot) => {
-          if (callback) callback(undefined, {uri: snapshot});
+          if (callback) {
+            callback(undefined, {
+              uri: snapshot,
+            });
+          }
           resolve(snapshot);
         }, (err) => {
           if (callback) callback(err);
           reject(err);
         });
-      }
-      else {
-        this._runCommand('takeSnapshot', [options.width, options.height, options.region, (err, snapshot) => {
-          if (callback) callback(err, snapshot);
-          if (err) {
-            reject(err);
-          }
-          else {
-            resolve(snapshot.uri);
-          }
-        }]);
+      } else {
+        this._runCommand('takeSnapshot', [
+          options.width,
+          options.height,
+          options.region,
+          (err, snapshot) => {
+            if (callback) callback(err, snapshot);
+            if (err) {
+              reject(err);
+            } else {
+              resolve(snapshot.uri);
+            }
+          },
+        ]);
       }
     });
   }


### PR DESCRIPTION
This pull request adds support for `takeSnapshot` on Android.

The takeSnapshot function was purposefully implemented on the AirMapModule class and not as a command on AirMapManager. The reason was that with using commands it is not possible to call the callback that is provided. The callback cannot be extracted from `ReadableMap`. This made it unsuitable for this specific function. I've taking inspiration from `react-native-view-shot` and was able to implement the functionality on the AirMapModule instead.

The region argument is not used on Android and the width and height are interpreted differently. This is because the `GoogleMaps.snapshot` doesn't take the size or region as input. This creates a feature difference with the iOS version.

Additionally, I've made `takeSnapshot` promise aware. This means it now returns a promise with the resulting snapshot value (the uri) (or rejects the promise in case of an error).

Android screenshot:
![image](https://cloud.githubusercontent.com/assets/6184593/18932647/a78c06a4-85d1-11e6-8906-29de8d0d46eb.png)
