### PR TITLE
Remove unused tileMap variable from AirMapView

### DIFF
--- a/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -70,8 +70,6 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     private static final String[] PERMISSIONS = new String[] {
             "android.permission.ACCESS_FINE_LOCATION", "android.permission.ACCESS_COARSE_LOCATION"};
 
-    // TODO: don't need tileMap at all???
-    private HashMap<TileOverlay, AirMapUrlTile> tileMap = new HashMap<>();
     private final List<AirMapFeature> features = new ArrayList<>();
     private final Map<Marker, AirMapMarker> markerMap = new HashMap<>();
     private final ScaleGestureDetector scaleDetector;
@@ -402,9 +400,6 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
             AirMapUrlTile urlTileView = (AirMapUrlTile) child;
             urlTileView.addToMap(map);
             features.add(index, urlTileView);
-            TileOverlay tile = (TileOverlay)urlTileView.getFeature();
-            // TODO: don't need tileMap at all???
-            tileMap.put(tile, urlTileView);
         } else {
             // TODO(lmr): throw? User shouldn't be adding non-feature children.
         }
@@ -422,9 +417,6 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
         AirMapFeature feature = features.remove(index);
         if (feature instanceof AirMapMarker) {
             markerMap.remove(feature.getFeature());
-        } else if (feature instanceof AirMapUrlTile) {
-            // TODO: don't need tileMap at all???
-            tileMap.remove(feature.getFeature());
         }
         feature.removeFromMap(map);
     }


### PR DESCRIPTION
Remove unused variable `tileMap`.

It was left over from a rebase from #595.

cc: @cascadian 