### PR TITLE
[google][ios] fix markers never going away for provider="google"

### DIFF
--- a/example/examples/DefaultMarkers.js
+++ b/example/examples/DefaultMarkers.js
@@ -4,6 +4,7 @@ import {
   View,
   Text,
   Dimensions,
+  TouchableOpacity,
 } from 'react-native';
 
 import MapView from 'react-native-maps';
@@ -67,9 +68,12 @@ class DefaultMarkers extends React.Component {
           ))}
         </MapView>
         <View style={styles.buttonContainer}>
-          <View style={styles.bubble}>
+          <TouchableOpacity
+            onPress={() => this.setState({ markers: [] })}
+            style={styles.bubble}
+          >
             <Text>Tap to create a marker of random color</Text>
-          </View>
+          </TouchableOpacity>
         </View>
       </View>
     );

--- a/ios/AirGoogleMaps/AIRGoogleMap.m
+++ b/ios/AirGoogleMaps/AIRGoogleMap.m
@@ -122,6 +122,13 @@ GMSCameraPosition* makeGMSCameraPositionFromMKCoordinateRegionOfMap(GMSMapView *
 }
 #pragma clang diagnostic pop
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wobjc-missing-super-calls"
+- (NSArray<id<RCTComponent>> *)reactSubviews {
+  return _reactSubviews;
+}
+#pragma clang diagnostic pop
+
 - (void)setInitialRegion:(MKCoordinateRegion)initialRegion {
   if (_initialRegionSet) return;
   _initialRegionSet = true;


### PR DESCRIPTION
Once created, markers were never going away. This PR fixes that. It also adds the ability to test this functionality in "Default Markers" demo.

![gb-markers](https://cloud.githubusercontent.com/assets/2136203/19009716/73bdf2f0-872b-11e6-966d-096aa445dc30.gif)

@spikebrehm @lelandrichardson 
@felipecsl 