### PR TITLE
If we've disabled scrolling within the map, then don't capture the touch events

### DIFF
--- a/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -578,13 +578,16 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
 
         switch (action) {
             case (MotionEvent.ACTION_DOWN):
-                this.getParent().requestDisallowInterceptTouchEvent(true);
+                if (map != null && map.getUiSettings().isScrollGesturesEnabled()) {
+                    this.getParent().requestDisallowInterceptTouchEvent(true);
+                }
                 isTouchDown = true;
                 break;
             case (MotionEvent.ACTION_MOVE):
                 startMonitoringRegion();
                 break;
             case (MotionEvent.ACTION_UP):
+                // Clear this regardless, since isScrollGesturesEnabled() may have been updated
                 this.getParent().requestDisallowInterceptTouchEvent(false);
                 isTouchDown = false;
                 break;

--- a/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -578,9 +578,8 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
 
         switch (action) {
             case (MotionEvent.ACTION_DOWN):
-                if (map != null && map.getUiSettings().isScrollGesturesEnabled()) {
-                    this.getParent().requestDisallowInterceptTouchEvent(true);
-                }
+                this.getParent().requestDisallowInterceptTouchEvent(
+                        map != null && map.getUiSettings().isScrollGesturesEnabled());
                 isTouchDown = true;
                 break;
             case (MotionEvent.ACTION_MOVE):


### PR DESCRIPTION
This allows the containing scrollview to perform a scrollview scroll by dragging on the map. (Previously, the map would absorb the touches, and then not scroll the map _or_ the scrollview, which was bad.)
