### PR TITLE
[android] fix getAirMapName to fix ref-based commands

### DIFF
--- a/components/decorateMapComponent.js
+++ b/components/decorateMapComponent.js
@@ -14,6 +14,7 @@ export const USES_DEFAULT_IMPLEMENTATION = 'USES_DEFAULT_IMPLEMENTATION';
 export const NOT_SUPPORTED = 'NOT_SUPPORTED';
 
 export function getAirMapName(provider) {
+  if (Platform.OS === 'android') return 'AIRMap';
   if (provider === PROVIDER_GOOGLE) return 'AIRGoogleMap';
   return 'AIRMap';
 }


### PR DESCRIPTION
stuff like `map.fitToElements()` was broken b/c of this.

![fitmap](https://cloud.githubusercontent.com/assets/2136203/19208439/ad6e429c-8cae-11e6-96ea-aebb719f0c11.gif)
