### PR TITLE
[android] Add parameter to disable the moving on marker press

### DIFF
--- a/android/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
+++ b/android/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
@@ -155,27 +155,27 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
         view.map.getUiSettings().setRotateGesturesEnabled(rotateEnabled);
     }
 
-    @ReactProp(name="cacheEnabled", defaultBoolean = false)
+    @ReactProp(name = "cacheEnabled", defaultBoolean = false)
     public void setCacheEnabled(AirMapView view, boolean cacheEnabled) {
         view.setCacheEnabled(cacheEnabled);
     }
 
-    @ReactProp(name="loadingEnabled", defaultBoolean = false)
+    @ReactProp(name = "loadingEnabled", defaultBoolean = false)
     public void setLoadingEnabled(AirMapView view, boolean loadingEnabled) {
         view.enableMapLoading(loadingEnabled);
     }
 
-    @ReactProp(name="moveOnMarkerPress", defaultBoolean = true)
+    @ReactProp(name = "moveOnMarkerPress", defaultBoolean = true)
     public void setMoveOnMarkerPress(AirMapView view, boolean moveOnPress) {
         view.setMoveOnMarkerPress(moveOnPress);
     }
 
-    @ReactProp(name="loadingBackgroundColor", customType="Color")
+    @ReactProp(name = "loadingBackgroundColor", customType = "Color")
     public void setLoadingBackgroundColor(AirMapView view, @Nullable Integer loadingBackgroundColor) {
         view.setLoadingBackgroundColor(loadingBackgroundColor);
     }
 
-    @ReactProp(name="loadingIndicatorColor", customType="Color")
+    @ReactProp(name = "loadingIndicatorColor", customType = "Color")
     public void setLoadingIndicatorColor(AirMapView view, @Nullable Integer loadingIndicatorColor) {
         view.setLoadingIndicatorColor(loadingIndicatorColor);
     }

--- a/android/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
+++ b/android/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
@@ -165,6 +165,11 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
         view.enableMapLoading(loadingEnabled);
     }
 
+    @ReactProp(name="moveOnMarkerPress", defaultBoolean = true)
+    public void setMoveOnMarkerPress(AirMapView view, boolean moveOnPress) {
+        view.setMoveOnMarkerPress(moveOnPress);
+    }
+
     @ReactProp(name="loadingBackgroundColor", customType="Color")
     public void setLoadingBackgroundColor(AirMapView view, @Nullable Integer loadingBackgroundColor) {
         view.setLoadingBackgroundColor(loadingBackgroundColor);

--- a/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -65,6 +65,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     private boolean isMonitoringRegion = false;
     private boolean isTouchDown = false;
     private boolean handlePanDrag = false;
+    private boolean moveOnMarkerPress = true;
     private boolean cacheEnabled = false;
 
     private static final String[] PERMISSIONS = new String[] {
@@ -154,7 +155,14 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
                 event.putString("action", "marker-press");
                 manager.pushEvent(markerMap.get(marker), "onPress", event);
 
-                return false; // returning false opens the callout window, if possible
+                // Return false to open the callout info window and center on the marker
+                // https://developers.google.com/android/reference/com/google/android/gms/maps/GoogleMap.OnMarkerClickListener
+                if (view.moveOnMarkerPress) {
+                  return false;
+                } else {
+                  marker.showInfoWindow();
+                  return true;
+                }
             }
         });
 
@@ -328,6 +336,10 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
         if (loadingEnabled && !this.isMapLoaded) {
             this.getMapLoadingLayoutView().setVisibility(View.VISIBLE);
         }
+    }
+
+    public void setMoveOnMarkerPress(boolean moveOnPress) {
+        this.moveOnMarkerPress = moveOnPress;
     }
 
     public void setLoadingBackgroundColor(Integer loadingBackgroundColor) {

--- a/components/MapView.js
+++ b/components/MapView.js
@@ -168,6 +168,14 @@ const propTypes = {
   toolbarEnabled: PropTypes.bool,
 
   /**
+   * A Boolean indicating whether on marker press the map will move to the pressed marker
+   * Default value is `true`
+   *
+   * @platform android
+   */
+  moveOnMarkerPress: PropTypes.bool,
+
+  /**
    * A Boolean indicating whether the map shows scale information.
    * Default value is `false`
    *


### PR DESCRIPTION
On iOS (Apple Maps) clicking a marker doesn't move the map but on Android clicking a marker causes the map to move.  This PR adds a property that lets that behavior be disabled.

Test plan (on Android):
* Verify the callout still appears when clicking a pin
* Verify the map moves if the property isn't specified
* Verify the map doesn't move if the property is set to false.

Before:
![before](https://cloud.githubusercontent.com/assets/19673711/19256851/800908b4-8f1f-11e6-9b1b-786342235e62.gif)

After:
![after](https://cloud.githubusercontent.com/assets/19673711/19256850/7e98e904-8f1f-11e6-9b03-d2a1cbdb4e1c.gif)
