### PR TITLE
Upgraded to RN 0.35

### DIFF
--- a/ios/AirMaps/AIRMapMarker.m
+++ b/ios/AirMaps/AIRMapMarker.m
@@ -215,6 +215,7 @@
                                                                          clipped:YES
                                                                       resizeMode:RCTResizeModeCenter
                                                                    progressBlock:nil
+                                                                partialLoadBlock:nil
                                                                  completionBlock:^(NSError *error, UIImage *image) {
                                                                      if (error) {
                                                                          // TODO(lmr): do something with the error?

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "peerDependencies": {
     "react": ">=15.3.0",
-    "react-native": ">=0.33.0"
+    "react-native": ">=0.35"
   },
   "devDependencies": {
     "babel-eslint": "^6.1.2",


### PR DESCRIPTION
added fix to RCTImageLoader, missing `partialLoadBlock:nil`

see https://github.com/airbnb/react-native-maps/blob/master/ios/AirMaps/AIRMapMarker.m#L217

```Objective-C
 _reloadImageCancellationBlock = [_bridge.imageLoader loadImageWithURLRequest:[RCTConvert NSURLRequest:_imageSrc]
                                                                            size:self.bounds.size
                                                                           scale:RCTScreenScale()
                                                                         clipped:YES
                                                                      resizeMode:RCTResizeModeCenter
                                                                   progressBlock:nil
                                                                partialLoadBlock:nil
                                                                 completionBlock:^(NSError *error, UIImage *image) {
                                                                     if (error) {
                                                                         // TODO(lmr): do something with the error?
                                                                         NSLog(@"%@", error);
                                                                     }
                                                                     dispatch_async(dispatch_get_main_queue(), ^{
                                                                         self.image = image;
                                                                     });
                                                                 }];
```