### PR TITLE
Update example app for RN 0.35, fix Gmaps bug for 0.35

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -4,27 +4,25 @@ PODS:
   - GoogleMaps/Base (2.1.0)
   - GoogleMaps/Maps (2.1.0):
     - GoogleMaps/Base (= 2.1.0)
-  - React/Core (0.33.0):
-    - React/CSSLayout
-  - React/CSSLayout (0.33.0)
-  - React/RCTActionSheet (0.33.0):
+  - React/Core (0.35.0)
+  - React/RCTActionSheet (0.35.0):
     - React/Core
-  - React/RCTGeolocation (0.33.0):
+  - React/RCTGeolocation (0.35.0):
     - React/Core
-  - React/RCTImage (0.33.0):
+  - React/RCTImage (0.35.0):
     - React/Core
     - React/RCTNetwork
-  - React/RCTLinkingIOS (0.33.0):
+  - React/RCTLinkingIOS (0.35.0):
     - React/Core
-  - React/RCTNetwork (0.33.0):
+  - React/RCTNetwork (0.35.0):
     - React/Core
-  - React/RCTSettings (0.33.0):
+  - React/RCTSettings (0.35.0):
     - React/Core
-  - React/RCTText (0.33.0):
+  - React/RCTText (0.35.0):
     - React/Core
-  - React/RCTVibration (0.33.0):
+  - React/RCTVibration (0.35.0):
     - React/Core
-  - React/RCTWebSocket (0.33.0):
+  - React/RCTWebSocket (0.35.0):
     - React/Core
 
 DEPENDENCIES:
@@ -46,6 +44,6 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   GoogleMaps: 06589b9a38097bce0cd6e90f0fd9b5e4b4a9344c
-  React: 46edc166689ba71b0b6cf11e64dbdb258d177089
+  React: d80af5410aa500d0cb1bce2cc4493a584cf2ec92
 
 COCOAPODS: 0.39.0

--- a/example/package.json
+++ b/example/package.json
@@ -9,8 +9,8 @@
     "dev": "concurrently 'npm run watch' 'npm run packager'"
   },
   "dependencies": {
-    "react": "15.3.0",
-    "react-native": "0.33.0",
+    "react": "^15.3.1",
+    "react-native": "^0.35.0",
     "react-native-maps": "../"
   },
   "devDependencies": {

--- a/ios/AirGoogleMaps/AIRGoogleMapMarker.m
+++ b/ios/AirGoogleMaps/AIRGoogleMapMarker.m
@@ -188,6 +188,7 @@ CGRect unionRect(CGRect a, CGRect b) {
                                                                        clipped:YES
                                                                     resizeMode:RCTResizeModeCenter
                                                                  progressBlock:nil
+                                                              partialLoadBlock:nil
                                                                completionBlock:^(NSError *error, UIImage *image) {
                                                                  if (error) {
                                                                    // TODO(lmr): do something with the error?

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "mapkit"
   ],
   "peerDependencies": {
-    "react": ">=15.3.0",
+    "react": ">=15.3.1",
     "react-native": ">=0.35"
   },
   "devDependencies": {


### PR DESCRIPTION
Update the example app for RN 0.35.0.

Also fix the same bug that #680 fixes but for `AIRGoogleMapMarker`.

Also update the React dependency to 15.3.1, which is required for RN => 0.34.

to: @lelandrichardson @gilbox @felipecsl 