### PR TITLE
[marker flicker]  Fix flicker of map pins on state change

### DIFF
--- a/components/decorateMapComponent.js
+++ b/components/decorateMapComponent.js
@@ -48,7 +48,7 @@ export default function decorateMapComponent(Component, { componentType, provide
     if (components[provider]) return components[provider];
 
     if (provider === PROVIDER_DEFAULT) {
-      components.default = getDefaultComponent();
+      if (!components.default) components.default = getDefaultComponent();
       return components.default;
     }
 

--- a/components/decorateMapComponent.js
+++ b/components/decorateMapComponent.js
@@ -48,8 +48,8 @@ export default function decorateMapComponent(Component, { componentType, provide
     if (components[provider]) return components[provider];
 
     if (provider === PROVIDER_DEFAULT) {
-      if (!components.default) components.default = getDefaultComponent();
-      return components.default;
+      components[PROVIDER_DEFAULT] = getDefaultComponent();
+      return components[PROVIDER_DEFAULT];
     }
 
     const providerInfo = providers[provider];
@@ -62,8 +62,8 @@ export default function decorateMapComponent(Component, { componentType, provide
         components[provider] = requireNativeComponent(componentName, Component);
       }
     } else { // (platformSupport === USES_DEFAULT_IMPLEMENTATION)
-      if (!components.default) components.default = getDefaultComponent();
-      components[provider] = components.default;
+      if (!components[PROVIDER_DEFAULT]) components[PROVIDER_DEFAULT] = getDefaultComponent();
+      components[provider] = components[PROVIDER_DEFAULT];
     }
 
     return components[provider];


### PR DESCRIPTION
Fixes https://github.com/airbnb/react-native-maps/issues/683 caused by https://github.com/airbnb/react-native-maps/pull/548.

In #548, MapMarker.js was changed from 
`const AIRMapMarker = requireNativeComponent('AIRMapMarker', MapMarker);` to 
`const AIRMapMarker = this.getAirComponent();`.  

`AirMapMarker` is what is returned in the render method.

The bug was that `this.getAirComponent()` was returning a new native component each time causing a re-render.  This only happened for the default component, not the other ones since they were cached.  The fix is to cache the default component.

Note: this seems to affect map markers with arbitrary views inside them the most.  

Before:
![before 2](https://cloud.githubusercontent.com/assets/19673711/19708521/f215bcee-9ad3-11e6-9a6b-dc1732146e87.gif)

After:
![after](https://cloud.githubusercontent.com/assets/19673711/19708485/b6cfa4ba-9ad3-11e6-8b92-aa6a5d793c1d.gif)
