### PR TITLE
Use latest Google Play Services

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -53,7 +53,7 @@ android {
 }
 
 dependencies {
-  compile 'com.facebook.react:react-native:+'
-  compile "com.google.android.gms:play-services-base:9.4.0"
-  compile 'com.google.android.gms:play-services-maps:9.4.0'
+  compile "com.facebook.react:react-native:+"
+  compile "com.google.android.gms:play-services-base:+"
+  compile "com.google.android.gms:play-services-maps:+"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,6 +54,6 @@ android {
 
 dependencies {
   compile "com.facebook.react:react-native:+"
-  compile "com.google.android.gms:play-services-base:+"
-  compile "com.google.android.gms:play-services-maps:+"
+  compile "com.google.android.gms:play-services-base:9.6.1"
+  compile "com.google.android.gms:play-services-maps:9.6.1"
 }


### PR DESCRIPTION
Switch to use the latest Google Play Services.  

The pain point is that by specifying a specific version it doesn't work with other libraries which specify the latest version of Google Play Services (which most do).  It causes a crash because when it is compiled it will include some of the latest version and some of 9.4.0 and then when it runs it crashes.

It's generally safe to assume users have the latest Google Play Services as the updates are pushed automatically.  As Google says "Google Play services gives you the freedom to use the newest APIs for popular Google services without worrying about device support. Updates to Google Play services are distributed automatically by the Google Play Store and new versions of the client library are delivered through the Android SDK Manager."

This matches a similar decision that was made to use `react-native:+` in #547 
