### PR TITLE
Fix dynamic imageSrc removal

### DIFF
--- a/ios/AirGoogleMaps/AIRGoogleMapMarker.m
+++ b/ios/AirGoogleMaps/AIRGoogleMapMarker.m
@@ -187,6 +187,13 @@ CGRect unionRect(CGRect a, CGRect b) {
     return;
   }
   
+  if (_iconImageView) {
+    // prevent glitch with marker (cf. https://github.com/airbnb/react-native-maps/issues/738)
+    UIImageView *empyImageView = [[UIImageView alloc] init];
+    _iconImageView = empyImageView;
+    [self iconViewInsertSubview:_iconImageView atIndex:0];
+  }
+  
   _reloadImageCancellationBlock = [_bridge.imageLoader loadImageWithURLRequest:[RCTConvert NSURLRequest:_imageSrc]
                                                                           size:self.bounds.size
                                                                          scale:RCTScreenScale()

--- a/ios/AirGoogleMaps/AIRGoogleMapMarker.m
+++ b/ios/AirGoogleMaps/AIRGoogleMapMarker.m
@@ -187,7 +187,7 @@ CGRect unionRect(CGRect a, CGRect b) {
     return;
   }
   
-  if (_iconImageView) {
+  if (!_iconImageView) {
     // prevent glitch with marker (cf. https://github.com/airbnb/react-native-maps/issues/738)
     UIImageView *empyImageView = [[UIImageView alloc] init];
     _iconImageView = empyImageView;

--- a/ios/AirGoogleMaps/AIRGoogleMapMarker.m
+++ b/ios/AirGoogleMaps/AIRGoogleMapMarker.m
@@ -182,6 +182,11 @@ CGRect unionRect(CGRect a, CGRect b) {
     _reloadImageCancellationBlock = nil;
   }
 
+  if (!_imageSrc) {
+    if (_iconImageView) [_iconImageView removeFromSuperview];
+    return;
+  }
+  
   _reloadImageCancellationBlock = [_bridge.imageLoader loadImageWithURLRequest:[RCTConvert NSURLRequest:_imageSrc]
                                                                           size:self.bounds.size
                                                                          scale:RCTScreenScale()


### PR DESCRIPTION
Prevent triggering irrelevant imageLoader call, thus avoiding an exception.
