### PR TITLE
Add onPress for polygons and polylines on iOS and Android

### DIFF
--- a/android/src/main/java/com/airbnb/android/react/maps/AirMapPolygon.java
+++ b/android/src/main/java/com/airbnb/android/react/maps/AirMapPolygon.java
@@ -102,6 +102,7 @@ public class AirMapPolygon extends AirMapFeature {
     @Override
     public void addToMap(GoogleMap map) {
         polygon = map.addPolygon(getPolygonOptions());
+        polygon.setClickable(true);
     }
 
     @Override

--- a/android/src/main/java/com/airbnb/android/react/maps/AirMapPolygonManager.java
+++ b/android/src/main/java/com/airbnb/android/react/maps/AirMapPolygonManager.java
@@ -8,9 +8,14 @@ import android.view.WindowManager;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
 
 public class AirMapPolygonManager extends ViewGroupManager<AirMapPolygon> {
     private final DisplayMetrics metrics;
@@ -66,5 +71,14 @@ public class AirMapPolygonManager extends ViewGroupManager<AirMapPolygon> {
     @ReactProp(name = "zIndex", defaultFloat = 1.0f)
     public void setZIndex(AirMapPolygon view, float zIndex) {
         view.setZIndex(zIndex);
+    }
+
+    @Override
+    @Nullable
+    public Map getExportedCustomDirectEventTypeConstants() {
+        Map map = MapBuilder.of(
+            "onPress", MapBuilder.of("registrationName", "onPress")
+        );
+        return map;
     }
 }

--- a/android/src/main/java/com/airbnb/android/react/maps/AirMapPolygonManager.java
+++ b/android/src/main/java/com/airbnb/android/react/maps/AirMapPolygonManager.java
@@ -76,9 +76,8 @@ public class AirMapPolygonManager extends ViewGroupManager<AirMapPolygon> {
     @Override
     @Nullable
     public Map getExportedCustomDirectEventTypeConstants() {
-        Map map = MapBuilder.of(
+        return MapBuilder.of(
             "onPress", MapBuilder.of("registrationName", "onPress")
         );
-        return map;
     }
 }

--- a/android/src/main/java/com/airbnb/android/react/maps/AirMapPolyline.java
+++ b/android/src/main/java/com/airbnb/android/react/maps/AirMapPolyline.java
@@ -92,6 +92,7 @@ public class AirMapPolyline extends AirMapFeature {
     @Override
     public void addToMap(GoogleMap map) {
         polyline = map.addPolyline(getPolylineOptions());
+        polyline.setClickable(true);
     }
 
     @Override

--- a/android/src/main/java/com/airbnb/android/react/maps/AirMapPolylineManager.java
+++ b/android/src/main/java/com/airbnb/android/react/maps/AirMapPolylineManager.java
@@ -8,9 +8,14 @@ import android.view.WindowManager;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
 
 public class AirMapPolylineManager extends ViewGroupManager<AirMapPolyline> {
     private final DisplayMetrics metrics;
@@ -61,5 +66,14 @@ public class AirMapPolylineManager extends ViewGroupManager<AirMapPolyline> {
     @ReactProp(name = "zIndex", defaultFloat = 1.0f)
     public void setZIndex(AirMapPolyline view, float zIndex) {
         view.setZIndex(zIndex);
+    }
+
+    @Override
+    @Nullable
+    public Map getExportedCustomDirectEventTypeConstants() {
+        Map map = MapBuilder.of(
+            "onPress", MapBuilder.of("registrationName", "onPress")
+        );
+        return map;
     }
 }

--- a/android/src/main/java/com/airbnb/android/react/maps/AirMapPolylineManager.java
+++ b/android/src/main/java/com/airbnb/android/react/maps/AirMapPolylineManager.java
@@ -71,9 +71,8 @@ public class AirMapPolylineManager extends ViewGroupManager<AirMapPolyline> {
     @Override
     @Nullable
     public Map getExportedCustomDirectEventTypeConstants() {
-        Map map = MapBuilder.of(
+        return MapBuilder.of(
             "onPress", MapBuilder.of("registrationName", "onPress")
         );
-        return map;
     }
 }

--- a/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -39,6 +39,8 @@ import com.google.android.gms.maps.model.CameraPosition;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.LatLngBounds;
 import com.google.android.gms.maps.model.Marker;
+import com.google.android.gms.maps.model.Polygon;
+import com.google.android.gms.maps.model.Polyline;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -72,6 +74,8 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
 
     private final List<AirMapFeature> features = new ArrayList<>();
     private final Map<Marker, AirMapMarker> markerMap = new HashMap<>();
+    private final Map<Polyline, AirMapPolyline> polylineMap = new HashMap<>();
+    private final Map<Polygon, AirMapPolygon> polygonMap = new HashMap<>();
     private final ScaleGestureDetector scaleDetector;
     private final GestureDetectorCompat gestureDetector;
     private final AirMapManager manager;
@@ -162,6 +166,26 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
                   marker.showInfoWindow();
                   return true;
                 }
+            }
+        });
+
+        map.setOnPolygonClickListener(new GoogleMap.OnPolygonClickListener() {
+            @Override
+            public void onPolygonClick(Polygon polygon) {
+                WritableMap event;
+                event = makeClickEventData(polygon.getPoints().get(0));
+                event.putString("action", "polygon-press");
+                manager.pushEvent(polygonMap.get(polygon), "onPress", event);
+            }
+        });
+
+        map.setOnPolylineClickListener(new GoogleMap.OnPolylineClickListener() {
+            @Override
+            public void onPolylineClick(Polyline polyline) {
+                WritableMap event;
+                event = makeClickEventData(polyline.getPoints().get(0));
+                event.putString("action", "polyline-press");
+                manager.pushEvent(polylineMap.get(polyline), "onPress", event);
             }
         });
 
@@ -381,10 +405,14 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
             AirMapPolyline polylineView = (AirMapPolyline) child;
             polylineView.addToMap(map);
             features.add(index, polylineView);
+            Polyline polyline = (Polyline) polylineView.getFeature();
+            polylineMap.put(polyline, polylineView);
         } else if (child instanceof AirMapPolygon) {
             AirMapPolygon polygonView = (AirMapPolygon) child;
             polygonView.addToMap(map);
             features.add(index, polygonView);
+            Polygon polygon = (Polygon) polygonView.getFeature();
+            polygonMap.put(polygon, polygonView);
         } else if (child instanceof AirMapCircle) {
             AirMapCircle circleView = (AirMapCircle) child;
             circleView.addToMap(map);

--- a/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -172,8 +172,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
         map.setOnPolygonClickListener(new GoogleMap.OnPolygonClickListener() {
             @Override
             public void onPolygonClick(Polygon polygon) {
-                WritableMap event;
-                event = makeClickEventData(polygon.getPoints().get(0));
+                WritableMap event = makeClickEventData(polygon.getPoints().get(0));
                 event.putString("action", "polygon-press");
                 manager.pushEvent(polygonMap.get(polygon), "onPress", event);
             }
@@ -182,8 +181,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
         map.setOnPolylineClickListener(new GoogleMap.OnPolylineClickListener() {
             @Override
             public void onPolylineClick(Polyline polyline) {
-                WritableMap event;
-                event = makeClickEventData(polyline.getPoints().get(0));
+                WritableMap event = makeClickEventData(polyline.getPoints().get(0));
                 event.putString("action", "polyline-press");
                 manager.pushEvent(polylineMap.get(polyline), "onPress", event);
             }

--- a/ios/AirMaps/AIRMapPolygon.h
+++ b/ios/AirMaps/AIRMapPolygon.h
@@ -32,6 +32,7 @@
 @property (nonatomic, assign) CGLineJoin lineJoin;
 @property (nonatomic, assign) CGFloat lineDashPhase;
 @property (nonatomic, strong) NSArray <NSNumber *> *lineDashPattern;
+@property (nonatomic, copy) RCTBubblingEventBlock onPress;
 
 #pragma mark MKOverlay protocol
 

--- a/ios/AirMaps/AIRMapPolygonManager.m
+++ b/ios/AirMaps/AIRMapPolygonManager.m
@@ -42,10 +42,7 @@ RCT_EXPORT_VIEW_PROPERTY(lineJoin, CGLineJoin)
 RCT_EXPORT_VIEW_PROPERTY(miterLimit, CGFloat)
 RCT_EXPORT_VIEW_PROPERTY(lineDashPhase, CGFloat)
 RCT_EXPORT_VIEW_PROPERTY(lineDashPattern, NSArray)
+RCT_EXPORT_VIEW_PROPERTY(onPress, RCTBubblingEventBlock)
 
-// NOTE(lmr):
-// for now, onPress events for overlays will be left unimplemented. Seems it is possible with some work, but
-// it is difficult to achieve in both ios and android so I decided to leave it out.
-//RCT_EXPORT_VIEW_PROPERTY(onPress, RCTBubblingEventBlock)
 
 @end

--- a/ios/AirMaps/AIRMapPolyline.h
+++ b/ios/AirMaps/AIRMapPolyline.h
@@ -31,6 +31,7 @@
 @property (nonatomic, assign) CGLineJoin lineJoin;
 @property (nonatomic, assign) CGFloat lineDashPhase;
 @property (nonatomic, strong) NSArray <NSNumber *> *lineDashPattern;
+@property (nonatomic, copy) RCTBubblingEventBlock onPress;
 
 #pragma mark MKOverlay protocol
 

--- a/ios/AirMaps/AIRMapPolylineManager.m
+++ b/ios/AirMaps/AIRMapPolylineManager.m
@@ -41,10 +41,6 @@ RCT_EXPORT_VIEW_PROPERTY(lineJoin, CGLineJoin)
 RCT_EXPORT_VIEW_PROPERTY(miterLimit, CGFloat)
 RCT_EXPORT_VIEW_PROPERTY(lineDashPhase, CGFloat)
 RCT_EXPORT_VIEW_PROPERTY(lineDashPattern, NSArray)
-
-// NOTE(lmr):
-// for now, onPress events for overlays will be left unimplemented. Seems it is possible with some work, but
-// it is difficult to achieve in both ios and android so I decided to leave it out.
-//RCT_EXPORT_VIEW_PROPERTY(onPress, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onPress, RCTBubblingEventBlock)
 
 @end


### PR DESCRIPTION
Adds onPress handlers for polygons and polylines.

- On Android, uses the native `setOnPolygonClickListener` and `setOnPolylineClickListener`
- On iOS, loops overlays in `handleMapTap` and finds if the tap is inside a polygon, or if the closest polyline is within 10 pixels of the tap.