### PR TITLE
Fixed callouts displaying behind markers.

### DIFF
--- a/components/MapCallout.js
+++ b/components/MapCallout.js
@@ -30,7 +30,7 @@ MapCallout.defaultProps = defaultProps;
 
 const styles = StyleSheet.create({
   callout: {
-    position: 'absolute',
+    position: 'relative',
   },
 });
 


### PR DESCRIPTION
Fixed callouts displaying behind markers. Now when a marker is selected, the corresponding callout renders in front of markers, rather than behind.

Implements change recommended by @nillo in #553

Fixes #553, fixes #662, fixes #751