### PR TITLE
Clarified documentation for `onRegionChange`

### DIFF
--- a/docs/mapview.md
+++ b/docs/mapview.md
@@ -34,8 +34,8 @@
 
 | Event Name | Returns | Notes
 |---|---|---|
-| `onRegionChange` | `Region` | Callback that is called continuously when the user is dragging the map.
-| `onRegionChangeComplete` | `Region` | Callback that is called once, when the user is done moving the map.
+| `onRegionChange` | `Region` | Callback that is called continuously when the region changes, such as when a user is dragging the map.
+| `onRegionChangeComplete` | `Region` | Callback that is called once when the region changes, such as when the user is done moving the map.
 | `onPress` | `{ coordinate: LatLng, position: Point }` | Callback that is called when user taps on the map.
 | `onPanDrag` | `{ coordinate: LatLng, position: Point }` | Callback that is called when user presses and drags the map. **NOTE**: for iOS `scrollEnabled` should be set to false to trigger the event
 | `onLongPress` | `{ coordinate: LatLng, position: Point }` | Callback that is called when user makes a "long press" somewhere on the map.


### PR DESCRIPTION
Updated the documentation to provide a better clarification on when `onRegionChange` fires, as it seems like it's exclusive to user input.

#827