### PR TITLE
Fixes #470. Support legalLabelInsets on Apple Maps

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -32,6 +32,7 @@ import CustomTiles from './examples/CustomTiles';
 import ZIndexMarkers from './examples/ZIndexMarkers';
 import StaticMap from './examples/StaticMap';
 import MapStyle from './examples/MapStyle';
+import LegalLabel from './examples/LegalLabel';
 
 const IOS = Platform.OS === 'ios';
 const ANDROID = Platform.OS === 'android';
@@ -142,6 +143,7 @@ class App extends React.Component {
       [CustomTiles, 'Custom Tiles', true],
       [ZIndexMarkers, 'Position Markers with Z-index', true],
       [MapStyle, 'Customize the style of the map', true],
+      [LegalLabel, 'Reposition the legal label', true],
     ]
     // Filter out examples that are not yet supported for Google Maps on iOS.
     .filter(example => ANDROID || (IOS && (example[2] || !this.state.useGoogleMaps)))

--- a/example/examples/LegalLabel.js
+++ b/example/examples/LegalLabel.js
@@ -1,0 +1,113 @@
+import React from 'react';
+import {
+  StyleSheet,
+  View,
+  Text,
+  Dimensions,
+} from 'react-native';
+
+import MapView from 'react-native-maps';
+
+const screen = Dimensions.get('window');
+
+class LegalLabel extends React.Component {
+  static propTypes = {
+    provider: MapView.ProviderPropType,
+  }
+
+  render() {
+    const latlng = {
+      latitude: 37.78825,
+      longitude: -122.4324,
+    };
+
+    const ASPECT_RATIO = screen.width / screen.height;
+    const LATITUDE_DELTA = 0.0922;
+    const LONGITUDE_DELTA = LATITUDE_DELTA * ASPECT_RATIO;
+
+    return (
+      <View style={{ ...StyleSheet.absoluteFillObject }}>
+        <MapView
+          provider={this.props.provider}
+          style={styles.map}
+          legalLabelInsets={{ bottom: 10, right: 10 }}
+          initialRegion={{
+            ...latlng,
+            latitudeDelta: LATITUDE_DELTA,
+            longitudeDelta: LONGITUDE_DELTA,
+          }}
+        >
+          <MapView.Marker coordinate={latlng} />
+        </MapView>
+
+        <View style={styles.username}>
+          <Text style={styles.usernameText}>Username</Text>
+        </View>
+
+        <View style={styles.bio}>
+          <Text style={styles.bioText}>
+            Bio description lorem ipsum Ullamco exercitation
+            aliqua ullamco nostrud dolor et aliquip fugiat do
+            aute fugiat velit in aliqua sit.
+          </Text>
+        </View>
+
+        <View style={styles.photo}>
+          <View style={styles.photoInner}>
+            <Text style={styles.photoText}>
+              Profile Photo
+            </Text>
+          </View>
+        </View>
+      </View>
+    );
+  }
+}
+
+const padding = 10;
+const photoSize = 80;
+const mapHeight = screen.height - 130;
+const styles = StyleSheet.create({
+  bio: {
+    marginHorizontal: padding,
+    marginBottom: 0,
+    paddingVertical: padding / 2,
+  },
+  bioText: {
+    fontSize: 16,
+    lineHeight: 16 * 1.5,
+  },
+  username: {
+    paddingLeft: photoSize + padding + padding,
+    paddingTop: padding,
+  },
+  usernameText: {
+    fontSize: 36,
+    lineHeight: 36,
+  },
+  photo: {
+    padding: 2,
+    position: 'absolute',
+    top: mapHeight - (photoSize / 2),
+    left: padding,
+    borderRadius: 5,
+    borderWidth: StyleSheet.hairlineWidth,
+    backgroundColor: '#ccc',
+    width: photoSize,
+    height: photoSize,
+  },
+  photoInner: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    flex: 1,
+  },
+  photoText: {
+    fontSize: 9,
+    textAlign: 'center',
+  },
+  map: {
+    height: mapHeight,
+  },
+});
+
+module.exports = LegalLabel;

--- a/ios/AirMaps/AIRMap.m
+++ b/ios/AirMaps/AIRMap.m
@@ -381,11 +381,11 @@ const CGFloat AIRMapZoomBoundBuffer = 0.01;
 
         [self updateScrollEnabled];
         [self updateZoomEnabled];
-        [self updateLegalLabelInset];
+        [self updateLegalLabelInsets];
     }
 }
 
-- (void)updateLegalLabelInset {
+- (void)updateLegalLabelInsets {
     if (_legalLabel) {
         dispatch_async(dispatch_get_main_queue(), ^{
             CGRect frame = self->_legalLabel.frame;

--- a/ios/AirMaps/AIRMap.m
+++ b/ios/AirMaps/AIRMap.m
@@ -381,6 +381,26 @@ const CGFloat AIRMapZoomBoundBuffer = 0.01;
 
         [self updateScrollEnabled];
         [self updateZoomEnabled];
+        [self updateLegalLabelInset];
+    }
+}
+
+- (void)updateLegalLabelInset {
+    if (_legalLabel) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            CGRect frame = self->_legalLabel.frame;
+            if (self->_legalLabelInsets.left) {
+                frame.origin.x = self->_legalLabelInsets.left;
+            } else if (self->_legalLabelInsets.right) {
+                frame.origin.x = self.frame.size.width - self->_legalLabelInsets.right - frame.size.width;
+            }
+            if (self->_legalLabelInsets.top) {
+                frame.origin.y = self->_legalLabelInsets.top;
+            } else if (self->_legalLabelInsets.bottom) {
+                frame.origin.y = self.frame.size.height - self->_legalLabelInsets.bottom - frame.size.height;
+            }
+            self->_legalLabel.frame = frame;
+        });
     }
 }
 

--- a/ios/AirMaps/AIRMap.m
+++ b/ios/AirMaps/AIRMap.m
@@ -388,18 +388,18 @@ const CGFloat AIRMapZoomBoundBuffer = 0.01;
 - (void)updateLegalLabelInsets {
     if (_legalLabel) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            CGRect frame = self->_legalLabel.frame;
-            if (self->_legalLabelInsets.left) {
-                frame.origin.x = self->_legalLabelInsets.left;
-            } else if (self->_legalLabelInsets.right) {
-                frame.origin.x = self.frame.size.width - self->_legalLabelInsets.right - frame.size.width;
+            CGRect frame = _legalLabel.frame;
+            if (_legalLabelInsets.left) {
+                frame.origin.x = _legalLabelInsets.left;
+            } else if (_legalLabelInsets.right) {
+                frame.origin.x = self.frame.size.width - _legalLabelInsets.right - frame.size.width;
             }
-            if (self->_legalLabelInsets.top) {
-                frame.origin.y = self->_legalLabelInsets.top;
-            } else if (self->_legalLabelInsets.bottom) {
-                frame.origin.y = self.frame.size.height - self->_legalLabelInsets.bottom - frame.size.height;
+            if (_legalLabelInsets.top) {
+                frame.origin.y = _legalLabelInsets.top;
+            } else if (_legalLabelInsets.bottom) {
+                frame.origin.y = self.frame.size.height - _legalLabelInsets.bottom - frame.size.height;
             }
-            self->_legalLabel.frame = frame;
+            _legalLabel.frame = frame;
         });
     }
 }


### PR DESCRIPTION
Fixes #470. This will add support for `legalLabelInsets` prop on iOS with Apple Maps. Code is adapted from RN core.