### PR TITLE
Allow legalLabelInsets to be changed and animated

### DIFF
--- a/docs/mapview.md
+++ b/docs/mapview.md
@@ -28,6 +28,7 @@
 | `loadingIndicatorColor` | `Color` | `#606060` | Sets loading indicator color, default to `#606060`.
 | `loadingBackgroundColor` | `Color` | `#FFFFFF` | Sets loading background color, default to `#FFFFFF`.
 | `moveOnMarkerPress` | `Boolean` | `true` | `Android only` If `false` the map won't move when a marker is pressed.
+| `legalLabelInsets` | `EdgeInsets` | | If set, changes the position of the "Legal" label link from the OS default. **Note:** iOS only.
 
 
 ## Events
@@ -101,5 +102,14 @@ type EdgePadding {
   right: Number,
   bottom: Number,
   left: Number
+}
+```
+
+```
+type EdgeInsets {
+  top: Number,
+  left: Number,
+  bottom: Number,
+  right: Number
 }
 ```

--- a/example/examples/LegalLabel.js
+++ b/example/examples/LegalLabel.js
@@ -23,7 +23,7 @@ class LegalLabel extends React.Component {
   }
 
   componentDidMount() {
-    this.state._legalLabelPositionY.addListener(({value}) => {
+    this.state._legalLabelPositionY.addListener(({ value }) => {
       this.setState({
         legalLabelPositionY: value,
       });

--- a/example/examples/LegalLabel.js
+++ b/example/examples/LegalLabel.js
@@ -3,7 +3,9 @@ import {
   StyleSheet,
   View,
   Text,
+  Animated,
   Dimensions,
+  TouchableOpacity,
 } from 'react-native';
 
 import MapView from 'react-native-maps';
@@ -13,6 +15,34 @@ const screen = Dimensions.get('window');
 class LegalLabel extends React.Component {
   static propTypes = {
     provider: MapView.ProviderPropType,
+  }
+
+  state = {
+    _legalLabelPositionY: new Animated.Value(10),
+    legalLabelPositionY: 10,
+  }
+
+  componentDidMount() {
+    this.state._legalLabelPositionY.addListener(({value}) => {
+      this.setState({
+        legalLabelPositionY: value,
+      });
+    });
+  }
+
+  componentWillUnmount() {
+    this.state._legalLabelPositionY.removeAllListeners();
+  }
+
+  onPressAnimate = () => {
+    Animated.sequence([
+      Animated.spring(this.state._legalLabelPositionY, {
+        toValue: 100,
+      }),
+      Animated.spring(this.state._legalLabelPositionY, {
+        toValue: 10,
+      }),
+    ]).start();
   }
 
   render() {
@@ -30,7 +60,7 @@ class LegalLabel extends React.Component {
         <MapView
           provider={this.props.provider}
           style={styles.map}
-          legalLabelInsets={{ bottom: 10, right: 10 }}
+          legalLabelInsets={{ bottom: this.state.legalLabelPositionY, right: 10 }}
           initialRegion={{
             ...latlng,
             latitudeDelta: LATITUDE_DELTA,
@@ -41,7 +71,9 @@ class LegalLabel extends React.Component {
         </MapView>
 
         <View style={styles.username}>
-          <Text style={styles.usernameText}>Username</Text>
+          <TouchableOpacity onPress={this.onPressAnimate}>
+            <Text style={styles.usernameText}>Animate</Text>
+          </TouchableOpacity>
         </View>
 
         <View style={styles.bio}>
@@ -84,6 +116,8 @@ const styles = StyleSheet.create({
   usernameText: {
     fontSize: 36,
     lineHeight: 36,
+    color: 'blue',
+    textDecorationLine: 'underline',
   },
   photo: {
     padding: 2,

--- a/ios/AirMaps/AIRMap.m
+++ b/ios/AirMaps/AIRMap.m
@@ -404,6 +404,12 @@ const CGFloat AIRMapZoomBoundBuffer = 0.01;
     }
 }
 
+
+- (void)setLegalLabelInsets:(UIEdgeInsets)legalLabelInsets {
+  _legalLabelInsets = legalLabelInsets;
+  [self updateLegalLabelInsets];
+}
+
 - (void)beginLoading {
     if ((!self.hasShownInitialLoading && self.loadingEnabled) || (self.cacheEnabled && self.cacheImageView.image == nil)) {
         self.loadingView.hidden = NO;


### PR DESCRIPTION
Added docs for legalLabelInsets as well. Related to #840 

While property is structurally identical to EdgePadding, used for region fitting, they serve completely
different purposes. So a new type is defined.

Default left empty since it's an OS default (around {left: 10, bottom: 10} in my tests)