### PR TITLE
changed google play dependency from 9.8.0 to point to latest version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,6 +54,6 @@ android {
 
 dependencies {
   compile "com.facebook.react:react-native:+"
-  compile "com.google.android.gms:play-services-base:9.8.0"
-  compile "com.google.android.gms:play-services-maps:9.8.0"
+  compile "com.google.android.gms:play-services-base:+"
+  compile "com.google.android.gms:play-services-maps:+"
 }


### PR DESCRIPTION
I upgraded react native maps and app was crashing on android redmi 3s prime. I changed google play base and maps dependency to '+' and it worked. Also it fixes [#831](https://github.com/airbnb/react-native-maps/issues/831) and [#874](https://github.com/airbnb/react-native-maps/issues/874)