### PR TITLE
[android crash]  Fix exception when animating region during initialization

### DIFF
--- a/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -479,13 +479,17 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     }
 
     public void animateToRegion(LatLngBounds bounds, int duration) {
-        startMonitoringRegion();
-        map.animateCamera(CameraUpdateFactory.newLatLngBounds(bounds, 0), duration, null);
+        if (map != null) {
+            startMonitoringRegion();
+            map.animateCamera(CameraUpdateFactory.newLatLngBounds(bounds, 0), duration, null);
+        }
     }
 
     public void animateToCoordinate(LatLng coordinate, int duration) {
-        startMonitoringRegion();
-        map.animateCamera(CameraUpdateFactory.newLatLng(coordinate), duration, null);
+        if (map != null) {
+            startMonitoringRegion();
+            map.animateCamera(CameraUpdateFactory.newLatLng(coordinate), duration, null);
+        }
     }
 
     public void fitToElements(boolean animated) {


### PR DESCRIPTION
Fixes a crash cause by calling animateToRegion on the map while it is still be initialized.

To reproduce:  
In the `componentDidMount` of the component that renders the `MapView` add a `    this._map.animateToRegion(region, 1500);`.

Basically on the native side we haven't initialized the `map` variable yet (which happens in `onMapReady`) so if that's the case we can't do an `animateToRegion` yet.

![screenshot-2016-12-15_14 08 08 230](https://cloud.githubusercontent.com/assets/19673711/21243918/023de7f8-c2d0-11e6-93da-7c03c7f8b54a.png)
