### PR TITLE
[doc, android] Adding section to fix gradle problems

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -73,6 +73,21 @@ After your `Podfile` is setup properly, run `pod install`.
      compile project(':react-native-maps')
    }
    ```
+   
+   If you have a different play serivces than the one included in this library, use the following instead:
+   
+   ```groovy
+   ...
+   dependencies {
+     ...
+     compile project(':react-native-maps'){
+       exclude group: 'com.google.android.gms', module: 'play-services-base'
+       exclude group: 'com.google.android.gms', module: 'play-services-maps'
+     }
+     compile 'com.google.android.gms:play-services-base:<Your play-services version>'
+     compile 'com.google.android.gms:play-services-maps:<Your play services version>'
+   }
+   ```
 
 1. In your `android/settings.gradle` add:
    >This step is not necessary if you ran "react-native link"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -74,18 +74,18 @@ After your `Podfile` is setup properly, run `pod install`.
    }
    ```
    
-   If you have a different play serivces than the one included in this library, use the following instead:
+   If you have a different play serivces than the one included in this library, use the following instead (switch 10.0.1 for the desired version):
    
    ```groovy
    ...
    dependencies {
-     ...
-     compile project(':react-native-maps'){
-       exclude group: 'com.google.android.gms', module: 'play-services-base'
-       exclude group: 'com.google.android.gms', module: 'play-services-maps'
-     }
-     compile 'com.google.android.gms:play-services-base:<Your play-services version>'
-     compile 'com.google.android.gms:play-services-maps:<Your play services version>'
+       ...
+       compile(project(':react-native-maps')){
+           exclude group: 'com.google.android.gms', module: 'play-services-base'
+           exclude group: 'com.google.android.gms', module: 'play-services-maps'
+       }
+       compile 'com.google.android.gms:play-services-base:10.0.1'
+       compile 'com.google.android.gms:play-services-maps:10.0.1'
    }
    ```
 


### PR DESCRIPTION
This adds a solution to fix the mismatch between the play-services in case the user wants to use a different version

This fixes #877,  #831 and #874 for all versions while keeping compatibility with projects using older version of play-services