### PR TITLE
[RN 0.40] Update iOS header imports and JS SyntheticEvent import for RN 0.40

### DIFF
--- a/example/examples/EventListener.js
+++ b/example/examples/EventListener.js
@@ -1,5 +1,4 @@
 import React, { PropTypes } from 'react';
-import SyntheticEvent from 'react/lib/SyntheticEvent';
 import {
   StyleSheet,
   View,
@@ -7,6 +6,8 @@ import {
   Dimensions,
   ScrollView,
 } from 'react-native';
+// eslint-disable-next-line max-len
+import SyntheticEvent from 'react-native/Libraries/Renderer/src/renderers/shared/stack/event/SyntheticEvent';
 import MapView from 'react-native-maps';
 import PriceMarker from './PriceMarker';
 

--- a/example/ios/AirMapsExplorer.xcodeproj/project.pbxproj
+++ b/example/ios/AirMapsExplorer.xcodeproj/project.pbxproj
@@ -32,7 +32,6 @@
 		21E6570C1D77591A00B75EE5 /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 21E6570B1D77591A00B75EE5 /* MobileCoreServices.framework */; };
 		21E6570E1D77591F00B75EE5 /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 21E6570D1D77591F00B75EE5 /* MapKit.framework */; };
 		21E657101D77594C00B75EE5 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 21E6570F1D77594C00B75EE5 /* AudioToolbox.framework */; };
-		3E4E0B5921E01BC4043FD8CD /* Pods_AirMapsExplorer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3591658C00398534590C8751 /* Pods_AirMapsExplorer.framework */; };
 		8620CC871DBD814A00B79BFE /* AIRGMSMarker.m in Sources */ = {isa = PBXBuildFile; fileRef = 8620CC6E1DBD814A00B79BFE /* AIRGMSMarker.m */; };
 		8620CC881DBD814A00B79BFE /* AIRGoogleMap.m in Sources */ = {isa = PBXBuildFile; fileRef = 8620CC701DBD814A00B79BFE /* AIRGoogleMap.m */; };
 		8620CC891DBD814A00B79BFE /* AIRGoogleMapCallout.m in Sources */ = {isa = PBXBuildFile; fileRef = 8620CC721DBD814A00B79BFE /* AIRGoogleMapCallout.m */; };
@@ -50,7 +49,7 @@
 		8697D6251DBEE22B00DB7D0F /* AIRGoogleMapCircleManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 8697D6241DBEE22B00DB7D0F /* AIRGoogleMapCircleManager.m */; };
 		86DE6F881DCE7D21002A5053 /* AIRGoogleMapUrlTile.m in Sources */ = {isa = PBXBuildFile; fileRef = 86DE6F871DCE7D21002A5053 /* AIRGoogleMapUrlTile.m */; };
 		86DE6F8B1DCE8543002A5053 /* AIRGoogleMapURLTileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 86DE6F8A1DCE8543002A5053 /* AIRGoogleMapURLTileManager.m */; };
-		C9315A21AD5A149EB5B40F29 /* Pods_AirMapsExplorer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 24EB66BA0860A4DCD4CA3D77 /* Pods_AirMapsExplorer.framework */; };
+		A622B8115793E41C70169A8B /* libPods-AirMapsExplorer.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0E5044A406006E7C2A53E05C /* libPods-AirMapsExplorer.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -66,6 +65,7 @@
 /* Begin PBXFileReference section */
 		008F07F21AC5B25A0029DE68 /* main.jsbundle */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = main.jsbundle; sourceTree = "<group>"; };
 		00E356EE1AD99517003FC87E /* AirMapsExplorerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AirMapsExplorerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		0E5044A406006E7C2A53E05C /* libPods-AirMapsExplorer.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AirMapsExplorer.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07F961A680F5B00A75B9A /* AirMapsExplorer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AirMapsExplorer.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = AirMapsExplorer/AppDelegate.h; sourceTree = "<group>"; };
 		13B07FB01A68108700A75B9A /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.m; path = AirMapsExplorer/AppDelegate.m; sourceTree = "<group>"; };
@@ -116,7 +116,6 @@
 		21E6570B1D77591A00B75EE5 /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
 		21E6570D1D77591F00B75EE5 /* MapKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MapKit.framework; path = System/Library/Frameworks/MapKit.framework; sourceTree = SDKROOT; };
 		21E6570F1D77594C00B75EE5 /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
-		3591658C00398534590C8751 /* Pods_AirMapsExplorer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AirMapsExplorer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8620CC6D1DBD814A00B79BFE /* AIRGMSMarker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIRGMSMarker.h; sourceTree = "<group>"; };
 		8620CC6E1DBD814A00B79BFE /* AIRGMSMarker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AIRGMSMarker.m; sourceTree = "<group>"; };
 		8620CC6F1DBD814A00B79BFE /* AIRGoogleMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIRGoogleMap.h; sourceTree = "<group>"; };
@@ -147,12 +146,12 @@
 		8697D6211DBEDE6100DB7D0F /* AIRGoogleMapCircle.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AIRGoogleMapCircle.m; sourceTree = "<group>"; };
 		8697D6231DBEE22B00DB7D0F /* AIRGoogleMapCircleManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIRGoogleMapCircleManager.h; sourceTree = "<group>"; };
 		8697D6241DBEE22B00DB7D0F /* AIRGoogleMapCircleManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AIRGoogleMapCircleManager.m; sourceTree = "<group>"; };
-		BE5DE1E9AE25978F88CD940A /* Pods-AirMapsExplorer.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AirMapsExplorer.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AirMapsExplorer/Pods-AirMapsExplorer.debug.xcconfig"; sourceTree = "<group>"; };
-		E138AD0CDB08FE57B09B18F8 /* Pods-AirMapsExplorer.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AirMapsExplorer.release.xcconfig"; path = "Pods/Target Support Files/Pods-AirMapsExplorer/Pods-AirMapsExplorer.release.xcconfig"; sourceTree = "<group>"; };
 		86DE6F861DCE7D21002A5053 /* AIRGoogleMapUrlTile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIRGoogleMapUrlTile.h; sourceTree = "<group>"; };
 		86DE6F871DCE7D21002A5053 /* AIRGoogleMapUrlTile.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AIRGoogleMapUrlTile.m; sourceTree = "<group>"; };
 		86DE6F891DCE8543002A5053 /* AIRGoogleMapUrlTileManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIRGoogleMapUrlTileManager.h; sourceTree = "<group>"; };
 		86DE6F8A1DCE8543002A5053 /* AIRGoogleMapURLTileManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AIRGoogleMapURLTileManager.m; sourceTree = "<group>"; };
+		BE5DE1E9AE25978F88CD940A /* Pods-AirMapsExplorer.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AirMapsExplorer.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AirMapsExplorer/Pods-AirMapsExplorer.debug.xcconfig"; sourceTree = "<group>"; };
+		E138AD0CDB08FE57B09B18F8 /* Pods-AirMapsExplorer.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AirMapsExplorer.release.xcconfig"; path = "Pods/Target Support Files/Pods-AirMapsExplorer/Pods-AirMapsExplorer.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -171,7 +170,7 @@
 				21E6570E1D77591F00B75EE5 /* MapKit.framework in Frameworks */,
 				21E6570C1D77591A00B75EE5 /* MobileCoreServices.framework in Frameworks */,
 				21E6570A1D77591400B75EE5 /* SystemConfiguration.framework in Frameworks */,
-				3E4E0B5921E01BC4043FD8CD /* Pods_AirMapsExplorer.framework in Frameworks */,
+				A622B8115793E41C70169A8B /* libPods-AirMapsExplorer.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -190,7 +189,7 @@
 				21E6570D1D77591F00B75EE5 /* MapKit.framework */,
 				21E6570B1D77591A00B75EE5 /* MobileCoreServices.framework */,
 				21E657091D77591400B75EE5 /* SystemConfiguration.framework */,
-				3591658C00398534590C8751 /* Pods_AirMapsExplorer.framework */,
+				0E5044A406006E7C2A53E05C /* libPods-AirMapsExplorer.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/example/ios/AirMapsExplorer/AppDelegate.m
+++ b/example/ios/AirMapsExplorer/AppDelegate.m
@@ -9,7 +9,7 @@
 
 #import "AppDelegate.h"
 
-#import "RCTRootView.h"
+#import <React/RCTRootView.h>
 
 #import <GoogleMaps/GoogleMaps.h>
 

--- a/example/ios/AirMapsExplorerTests/AirMapsExplorerTests.m
+++ b/example/ios/AirMapsExplorerTests/AirMapsExplorerTests.m
@@ -10,8 +10,8 @@
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
 
-#import "RCTLog.h"
-#import "RCTRootView.h"
+#import <React/RCTLog.h>
+#import <React/RCTRootView.h>
 
 #define TIMEOUT_SECONDS 240
 #define TEXT_TO_LOOK_FOR @"Welcome to React Native!"

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,18 +1,14 @@
-# You Podfile should look similar to this file. Whether you use_frameworks! or not, the following configuration should work.
-#
-# However if you DO NOT use_frameworks! and you prefer to install pods instead of
-# dragging the AirMaps directory into your project, refer to the comments below (steps 1~4)
-
+# You Podfile should look similar to this file. React Native currently does not support use_frameworks!
 source 'https://github.com/CocoaPods/Specs.git'
 
 platform :ios, '8.0'
-use_frameworks!
 
 # Change 'AirMapsExplorer' to match the target in your Xcode project.
 target 'AirMapsExplorer' do
   pod 'React', path: '../node_modules/react-native', :subspecs => [
     'Core',
     'RCTActionSheet',
+    'RCTAnimation',
     'RCTGeolocation',
     'RCTImage',
     'RCTLinkingIOS',
@@ -23,29 +19,9 @@ target 'AirMapsExplorer' do
     'RCTWebSocket'
   ]
 
-# when not using frameworks  we can do this instead of including the source files in our project (1/4):
-# pod 'react-native-maps', path: '../../'
-#	pod 'react-native-google-maps', path: '../../'  # <~~ if you need GoogleMaps support on iOS
-
-# when not using frameworks  we can remove this line (2/4):
   pod 'GoogleMaps'  # <~~ remove this line if you do not want to support GoogleMaps on iOS
+
+# when not using frameworks  we can do this instead of including the source files in our project (1/4):
+#  pod 'react-native-maps', path: '../../'
+#  pod 'react-native-google-maps', path: '../../'  # <~~ if you need GoogleMaps support on iOS
 end
-
-# when not using frameworks this might be necessary, but try without it first and see if `pod install` works (3/4):
-# THIS IS ONLY NECESSARY IF YOU NEED GoogleMaps SUPPORT
-# pre_install do |installer|
-  # # copied from https://github.com/CocoaPods/CocoaPods/issues/2926
-  # # workaround for https://github.com/CocoaPods/CocoaPods/issues/3289
-  # def installer.verify_no_static_framework_transitive_dependencies; end
-# end
-
-# when not using frameworks (4/4):
-# THIS IS ONLY NECESSARY IF YOU NEED GoogleMaps SUPPORT
-# #Crud, this shouldn't be necessary, but https://github.com/CocoaPods/CocoaPods/issues/5429
-# post_install do |installer|
-#   	installer.pods_project.targets.each do |target|
-# 		target.build_configurations.each do |config|
-#       		config.build_settings['CLANG_ENABLE_MODULES'] = 'NO'
-#     	end
-#   	end
-# end

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,34 +1,43 @@
 PODS:
-  - GoogleMaps (2.1.0):
-    - GoogleMaps/Maps (= 2.1.0)
-  - GoogleMaps/Base (2.1.0)
-  - GoogleMaps/Maps (2.1.0):
-    - GoogleMaps/Base (= 2.1.0)
-  - React/Core (0.35.0)
-  - React/RCTActionSheet (0.35.0):
+  - GoogleMaps (2.1.1):
+    - GoogleMaps/Maps (= 2.1.1)
+  - GoogleMaps/Base (2.1.1)
+  - GoogleMaps/Maps (2.1.1):
+    - GoogleMaps/Base
+  - React/Core (0.40.0):
+    - React/cxxreact
+    - React/yoga
+  - React/cxxreact (0.40.0):
+    - React/jschelpers
+  - React/jschelpers (0.40.0)
+  - React/RCTActionSheet (0.40.0):
     - React/Core
-  - React/RCTGeolocation (0.35.0):
+  - React/RCTAnimation (0.40.0):
     - React/Core
-  - React/RCTImage (0.35.0):
+  - React/RCTGeolocation (0.40.0):
+    - React/Core
+  - React/RCTImage (0.40.0):
     - React/Core
     - React/RCTNetwork
-  - React/RCTLinkingIOS (0.35.0):
+  - React/RCTLinkingIOS (0.40.0):
     - React/Core
-  - React/RCTNetwork (0.35.0):
+  - React/RCTNetwork (0.40.0):
     - React/Core
-  - React/RCTSettings (0.35.0):
+  - React/RCTSettings (0.40.0):
     - React/Core
-  - React/RCTText (0.35.0):
+  - React/RCTText (0.40.0):
     - React/Core
-  - React/RCTVibration (0.35.0):
+  - React/RCTVibration (0.40.0):
     - React/Core
-  - React/RCTWebSocket (0.35.0):
+  - React/RCTWebSocket (0.40.0):
     - React/Core
+  - React/yoga (0.40.0)
 
 DEPENDENCIES:
   - GoogleMaps
   - React/Core (from `../node_modules/react-native`)
   - React/RCTActionSheet (from `../node_modules/react-native`)
+  - React/RCTAnimation (from `../node_modules/react-native`)
   - React/RCTGeolocation (from `../node_modules/react-native`)
   - React/RCTImage (from `../node_modules/react-native`)
   - React/RCTLinkingIOS (from `../node_modules/react-native`)
@@ -43,9 +52,9 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native"
 
 SPEC CHECKSUMS:
-  GoogleMaps: 06589b9a38097bce0cd6e90f0fd9b5e4b4a9344c
-  React: d80af5410aa500d0cb1bce2cc4493a584cf2ec92
+  GoogleMaps: a5b5bbe47734e2443bde781a6aa64e69fdb6d785
+  React: 6dfb2f72edb1d74a800127ae157af038646673ce
 
-PODFILE CHECKSUM: be65689c848eff5d4099a483239b72acab62f6a4
+PODFILE CHECKSUM: ffbc20bd08f662256d501d07a70e77862684f702
 
 COCOAPODS: 1.1.1

--- a/example/package.json
+++ b/example/package.json
@@ -9,9 +9,9 @@
     "dev": "concurrently 'npm run watch' 'npm run packager'"
   },
   "dependencies": {
-    "react": "^15.3.1",
-    "react-native": "^0.35.0",
-    "react-native-maps": "../"
+    "react": "~15.4.1",
+    "react-native": "^0.40.0",
+    "react-native-maps": "file:../"
   },
   "devDependencies": {
     "concurrently": "^2.2.0",

--- a/ios/AirGoogleMaps/AIRGMSMarker.h
+++ b/ios/AirGoogleMaps/AIRGMSMarker.h
@@ -6,7 +6,7 @@
 //
 
 #import <GoogleMaps/GoogleMaps.h>
-#import "UIView+React.h"
+#import <React/UIView+React.h>
 
 @class AIRGoogleMapMarker;
 

--- a/ios/AirGoogleMaps/AIRGoogleMap.h
+++ b/ios/AirGoogleMaps/AIRGoogleMap.h
@@ -6,10 +6,10 @@
 //
 
 #import <UIKit/UIKit.h>
-#import "RCTComponent.h"
+#import <React/RCTComponent.h>
+#import <React/RCTConvert+MapKit.h>
 #import <GoogleMaps/GoogleMaps.h>
 #import <MapKit/MapKit.h>
-#import "RCTConvert+MapKit.h"
 #import "AIRGMSMarker.h"
 
 @interface AIRGoogleMap : GMSMapView

--- a/ios/AirGoogleMaps/AIRGoogleMap.m
+++ b/ios/AirGoogleMaps/AIRGoogleMap.m
@@ -13,8 +13,8 @@
 #import "AIRGoogleMapUrlTile.h"
 #import <GoogleMaps/GoogleMaps.h>
 #import <MapKit/MapKit.h>
-#import "RCTConvert+MapKit.h"
-#import "UIView+React.h"
+#import <React/RCTConvert+MapKit.h>
+#import <React/UIView+React.h>
 
 id regionAsJSON(MKCoordinateRegion region) {
   return @{

--- a/ios/AirGoogleMaps/AIRGoogleMapCallout.h
+++ b/ios/AirGoogleMaps/AIRGoogleMapCallout.h
@@ -7,7 +7,7 @@
 //
 
 #import <UIKit/UIKit.h>
-#import "RCTView.h"
+#import <React/RCTView.h>
 
 @interface AIRGoogleMapCallout : UIView
 @property (nonatomic, assign) BOOL tooltip;

--- a/ios/AirGoogleMaps/AIRGoogleMapCallout.m
+++ b/ios/AirGoogleMaps/AIRGoogleMapCallout.m
@@ -7,9 +7,9 @@
 //
 
 #import "AIRGoogleMapCallout.h"
-#import "RCTUtils.h"
-#import "RCTView.h"
-#import "RCTBridge.h"
+#import <React/RCTUtils.h>
+#import <React/RCTView.h>
+#import <React/RCTBridge.h>
 
 @implementation AIRGoogleMapCallout
 @end

--- a/ios/AirGoogleMaps/AIRGoogleMapCalloutManager.h
+++ b/ios/AirGoogleMaps/AIRGoogleMapCalloutManager.h
@@ -5,7 +5,7 @@
 //  Created by Gil Birman on 9/6/16.
 //
 //
-#import "RCTViewManager.h"
+#import <React/RCTViewManager.h>
 
 @interface AIRGoogleMapCalloutManager : RCTViewManager
 

--- a/ios/AirGoogleMaps/AIRGoogleMapCalloutManager.m
+++ b/ios/AirGoogleMaps/AIRGoogleMapCalloutManager.m
@@ -8,7 +8,7 @@
 
 #import "AIRGoogleMapCalloutManager.h"
 #import "AIRGoogleMapCallout.h"
-#import "RCTView.h"
+#import <React/RCTView.h>
 
 @implementation AIRGoogleMapCalloutManager
 RCT_EXPORT_MODULE()

--- a/ios/AirGoogleMaps/AIRGoogleMapCircle.m
+++ b/ios/AirGoogleMaps/AIRGoogleMapCircle.m
@@ -6,7 +6,7 @@
 #import <UIKit/UIKit.h>
 #import "AIRGoogleMapCircle.h"
 #import <GoogleMaps/GoogleMaps.h>
-#import "RCTUtils.h"
+#import <React/RCTUtils.h>
 
 @implementation AIRGoogleMapCircle
 

--- a/ios/AirGoogleMaps/AIRGoogleMapCircleManager.h
+++ b/ios/AirGoogleMaps/AIRGoogleMapCircleManager.h
@@ -4,7 +4,7 @@
 //  Created by Nick Italiano on 10/24/16.
 //
 
-#import "RCTViewManager.h"
+#import <React/RCTViewManager.h>
 
 @interface AIRGoogleMapCircleManager : RCTViewManager
 

--- a/ios/AirGoogleMaps/AIRGoogleMapCircleManager.m
+++ b/ios/AirGoogleMaps/AIRGoogleMapCircleManager.m
@@ -6,8 +6,8 @@
 
 #import "AIRGoogleMapCircleManager.h"
 #import "AIRGoogleMapCircle.h"
-#import "RCTBridge.h"
-#import "UIView+React.h"
+#import <React/RCTBridge.h>
+#import <React/UIView+React.h>
 
 @interface AIRGoogleMapCircleManager()
 

--- a/ios/AirGoogleMaps/AIRGoogleMapManager.h
+++ b/ios/AirGoogleMaps/AIRGoogleMapManager.h
@@ -5,7 +5,7 @@
 //  Created by Gil Birman on 9/1/16.
 //
 
-#import "RCTViewManager.h"
+#import <React/RCTViewManager.h>
 
 @interface AIRGoogleMapManager : RCTViewManager
 

--- a/ios/AirGoogleMaps/AIRGoogleMapManager.m
+++ b/ios/AirGoogleMaps/AIRGoogleMapManager.m
@@ -7,18 +7,18 @@
 
 
 #import "AIRGoogleMapManager.h"
-#import "RCTViewManager.h"
-#import "RCTBridge.h"
-#import "RCTUIManager.h"
-#import "RCTConvert+CoreLocation.h"
-#import "RCTConvert+MapKit.h"
+#import <React/RCTViewManager.h>
+#import <React/RCTBridge.h>
+#import <React/RCTUIManager.h>
+#import <React/RCTConvert+CoreLocation.h>
+#import <React/RCTConvert+MapKit.h>
+#import <React/RCTEventDispatcher.h>
+#import <React/RCTViewManager.h>
+#import <React/RCTConvert.h>
+#import <React/UIView+React.h>
 #import "RCTConvert+GMSMapViewType.h"
-#import "RCTEventDispatcher.h"
 #import "AIRGoogleMap.h"
-#import "UIView+React.h"
 #import "AIRMapMarker.h"
-#import "RCTViewManager.h"
-#import "RCTConvert.h"
 #import "AIRMapPolyline.h"
 #import "AIRMapPolygon.h"
 #import "AIRMapCircle.h"

--- a/ios/AirGoogleMaps/AIRGoogleMapMarker.h
+++ b/ios/AirGoogleMaps/AIRGoogleMapMarker.h
@@ -6,8 +6,8 @@
 //
 
 #import <GoogleMaps/GoogleMaps.h>
+#import <React/RCTBridge.h>
 #import "AIRGMSMarker.h"
-#import "RCTBridge.h"
 #import "AIRGoogleMap.h"
 #import "AIRGoogleMapCallout.h"
 

--- a/ios/AirGoogleMaps/AIRGoogleMapMarker.m
+++ b/ios/AirGoogleMaps/AIRGoogleMapMarker.m
@@ -7,10 +7,10 @@
 
 #import "AIRGoogleMapMarker.h"
 #import <GoogleMaps/GoogleMaps.h>
+#import <React/RCTImageLoader.h>
+#import <React/RCTUtils.h>
 #import "AIRGMSMarker.h"
 #import "AIRGoogleMapCallout.h"
-#import "RCTImageLoader.h"
-#import "RCTUtils.h"
 #import "DummyView.h"
 
 CGRect unionRect(CGRect a, CGRect b) {
@@ -186,14 +186,14 @@ CGRect unionRect(CGRect a, CGRect b) {
     if (_iconImageView) [_iconImageView removeFromSuperview];
     return;
   }
-  
+
   if (!_iconImageView) {
     // prevent glitch with marker (cf. https://github.com/airbnb/react-native-maps/issues/738)
     UIImageView *empyImageView = [[UIImageView alloc] init];
     _iconImageView = empyImageView;
     [self iconViewInsertSubview:_iconImageView atIndex:0];
   }
-  
+
   _reloadImageCancellationBlock = [_bridge.imageLoader loadImageWithURLRequest:[RCTConvert NSURLRequest:_imageSrc]
                                                                           size:self.bounds.size
                                                                          scale:RCTScreenScale()

--- a/ios/AirGoogleMaps/AIRGoogleMapMarkerManager.h
+++ b/ios/AirGoogleMaps/AIRGoogleMapMarkerManager.h
@@ -5,7 +5,7 @@
 //  Created by Gil Birman on 9/2/16.
 //
 
-#import "RCTViewManager.h"
+#import <React/RCTViewManager.h>
 
 @interface AIRGoogleMapMarkerManager : RCTViewManager
 

--- a/ios/AirGoogleMaps/AIRGoogleMapMarkerManager.m
+++ b/ios/AirGoogleMaps/AIRGoogleMapMarkerManager.m
@@ -8,8 +8,8 @@
 #import "AIRGoogleMapMarkerManager.h"
 #import "AIRGoogleMapMarker.h"
 #import <MapKit/MapKit.h>
-#import "RCTConvert+MapKit.h"
-#import "RCTUIManager.h"
+#import <React/RCTConvert+MapKit.h>
+#import <React/RCTUIManager.h>
 
 @implementation AIRGoogleMapMarkerManager
 

--- a/ios/AirGoogleMaps/AIRGoogleMapPolygonManager.h
+++ b/ios/AirGoogleMaps/AIRGoogleMapPolygonManager.h
@@ -4,7 +4,7 @@
 //  Created by Nick Italiano on 10/22/16.
 //
 
-#import "RCTViewManager.h"
+#import <React/RCTViewManager.h>
 
 @interface AIRGoogleMapPolygonManager : RCTViewManager
 

--- a/ios/AirGoogleMaps/AIRGoogleMapPolygonManager.m
+++ b/ios/AirGoogleMaps/AIRGoogleMapPolygonManager.m
@@ -5,13 +5,13 @@
 //
 #import "AIRGoogleMapPolygonManager.h"
 
-#import "RCTBridge.h"
-#import "RCTConvert.h"
-#import "RCTConvert+CoreLocation.h"
+#import <React/RCTBridge.h>
+#import <React/RCTConvert.h>
+#import <React/RCTConvert+CoreLocation.h>
+#import <React/RCTEventDispatcher.h>
+#import <React/RCTViewManager.h>
+#import <React/UIView+React.h>
 #import "RCTConvert+MoreMapKit.h"
-#import "RCTEventDispatcher.h"
-#import "UIView+React.h"
-#import "RCTViewManager.h"
 #import "AIRGoogleMapPolygon.h"
 
 @interface AIRGoogleMapPolygonManager()

--- a/ios/AirGoogleMaps/AIRGoogleMapPolyline.m
+++ b/ios/AirGoogleMaps/AIRGoogleMapPolyline.m
@@ -9,7 +9,7 @@
 #import "AIRGoogleMapMarker.h"
 #import "AIRGoogleMapMarkerManager.h"
 #import <GoogleMaps/GoogleMaps.h>
-#import "RCTUtils.h"
+#import <React/RCTUtils.h>
 
 @implementation AIRGoogleMapPolyline
 

--- a/ios/AirGoogleMaps/AIRGoogleMapPolylineManager.h
+++ b/ios/AirGoogleMaps/AIRGoogleMapPolylineManager.h
@@ -4,7 +4,7 @@
 //  Created by Nick Italiano on 10/22/16.
 //
 
-#import "RCTViewManager.h"
+#import <React/RCTViewManager.h>
 
 @interface AIRGoogleMapPolylineManager : RCTViewManager
 

--- a/ios/AirGoogleMaps/AIRGoogleMapPolylineManager.m
+++ b/ios/AirGoogleMaps/AIRGoogleMapPolylineManager.m
@@ -6,13 +6,13 @@
 
 #import "AIRGoogleMapPolylineManager.h"
 
-#import "RCTBridge.h"
-#import "RCTConvert.h"
-#import "RCTConvert+CoreLocation.h"
+#import <React/RCTBridge.h>
+#import <React/RCTConvert.h>
+#import <React/RCTConvert+CoreLocation.h>
+#import <React/RCTEventDispatcher.h>
+#import <React/RCTViewManager.h>
+#import <React/UIView+React.h>
 #import "RCTConvert+MoreMapKit.h"
-#import "RCTEventDispatcher.h"
-#import "UIView+React.h"
-#import "RCTViewManager.h"
 #import "AIRGoogleMapPolyline.h"
 
 @interface AIRGoogleMapPolylineManager()

--- a/ios/AirGoogleMaps/AIRGoogleMapUrlTileManager.h
+++ b/ios/AirGoogleMaps/AIRGoogleMapUrlTileManager.h
@@ -4,7 +4,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "RCTViewManager.h"
+#import <React/RCTViewManager.h>
 
 @interface AIRGoogleMapUrlTileManager : RCTViewManager
 @end

--- a/ios/AirGoogleMaps/RCTConvert+GMSMapViewType.h
+++ b/ios/AirGoogleMaps/RCTConvert+GMSMapViewType.h
@@ -6,7 +6,7 @@
 
 #import <Foundation/Foundation.h>
 #import <GoogleMaps/GoogleMaps.h>
-#import "RCTConvert.h"
+#import <React/RCTConvert.h>
 
 @interface RCTConvert (GMSMapViewType)
 

--- a/ios/AirGoogleMaps/RCTConvert+GMSMapViewType.m
+++ b/ios/AirGoogleMaps/RCTConvert+GMSMapViewType.m
@@ -6,7 +6,7 @@
 
 #import "RCTConvert+GMSMapViewType.h"
 #import <GoogleMaps/GoogleMaps.h>
-#import "RCTConvert.h"
+#import <React/RCTConvert.h>
 
 @implementation RCTConvert (GMSMapViewType)
   RCT_ENUM_CONVERTER(GMSMapViewType,

--- a/ios/AirMaps/AIRMap.h
+++ b/ios/AirMaps/AIRMap.h
@@ -10,8 +10,8 @@
 #import <MapKit/MapKit.h>
 #import <UIKit/UIKit.h>
 
-#import "RCTConvert+MapKit.h"
-#import "RCTComponent.h"
+#import <React/RCTConvert+MapKit.h>
+#import <React/RCTComponent.h>
 #import "SMCalloutView.h"
 
 extern const CLLocationDegrees AIRMapDefaultSpan;

--- a/ios/AirMaps/AIRMap.m
+++ b/ios/AirMaps/AIRMap.m
@@ -9,9 +9,9 @@
 
 #import "AIRMap.h"
 
-#import "RCTEventDispatcher.h"
+#import <React/RCTEventDispatcher.h>
+#import <React/UIView+React.h>
 #import "AIRMapMarker.h"
-#import "UIView+React.h"
 #import "AIRMapPolyline.h"
 #import "AIRMapPolygon.h"
 #import "AIRMapCircle.h"

--- a/ios/AirMaps/AIRMapCallout.h
+++ b/ios/AirMaps/AIRMapCallout.h
@@ -4,7 +4,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "RCTView.h"
+#import <React/RCTView.h>
 
 
 @interface AIRMapCallout : RCTView

--- a/ios/AirMaps/AIRMapCalloutManager.h
+++ b/ios/AirMaps/AIRMapCalloutManager.h
@@ -3,7 +3,7 @@
 // Copyright (c) 2015 Facebook. All rights reserved.
 //
 
-#import "RCTViewManager.h"
+#import <React/RCTViewManager.h>
 
 
 @interface AIRMapCalloutManager : RCTViewManager

--- a/ios/AirMaps/AIRMapCalloutManager.m
+++ b/ios/AirMaps/AIRMapCalloutManager.m
@@ -9,13 +9,13 @@
 
 #import "AIRMapCalloutManager.h"
 
-#import "RCTBridge.h"
-#import "RCTConvert.h"
-#import "RCTConvert+CoreLocation.h"
-#import "RCTEventDispatcher.h"
-#import "UIView+React.h"
+#import <React/RCTBridge.h>
+#import <React/RCTConvert.h>
+#import <React/RCTConvert+CoreLocation.h>
+#import <React/RCTEventDispatcher.h>
+#import <React/RCTViewManager.h>
+#import <React/UIView+React.h>
 #import "AIRMapMarker.h"
-#import "RCTViewManager.h"
 #import "AIRMapCallout.h"
 
 @interface AIRMapCalloutManager()

--- a/ios/AirMaps/AIRMapCircle.h
+++ b/ios/AirMaps/AIRMapCircle.h
@@ -8,13 +8,12 @@
 #import <MapKit/MapKit.h>
 #import <UIKit/UIKit.h>
 
-#import "RCTConvert+MapKit.h"
-#import "RCTComponent.h"
+#import <React/RCTConvert+MapKit.h>
+#import <React/RCTComponent.h>
+#import <React/RCTView.h>
+
 #import "AIRMapCoordinate.h"
 #import "AIRMap.h"
-#import "RCTView.h"
-
-
 
 @interface AIRMapCircle: MKAnnotationView <MKOverlay>
 

--- a/ios/AirMaps/AIRMapCircle.m
+++ b/ios/AirMaps/AIRMapCircle.m
@@ -4,7 +4,7 @@
 //
 
 #import "AIRMapCircle.h"
-#import "UIView+React.h"
+#import <React/UIView+React.h>
 
 
 @implementation AIRMapCircle {

--- a/ios/AirMaps/AIRMapCircleManager.h
+++ b/ios/AirMaps/AIRMapCircleManager.h
@@ -3,7 +3,7 @@
 // Copyright (c) 2015 Facebook. All rights reserved.
 //
 
-#import "RCTViewManager.h"
+#import <React/RCTViewManager.h>
 
 
 @interface AIRMapCircleManager : RCTViewManager

--- a/ios/AirMaps/AIRMapCircleManager.m
+++ b/ios/AirMaps/AIRMapCircleManager.m
@@ -9,13 +9,13 @@
 
 #import "AIRMapCircleManager.h"
 
-#import "RCTBridge.h"
-#import "RCTConvert.h"
-#import "RCTConvert+CoreLocation.h"
-#import "RCTEventDispatcher.h"
-#import "UIView+React.h"
+#import <React/RCTBridge.h>
+#import <React/RCTConvert.h>
+#import <React/RCTConvert+CoreLocation.h>
+#import <React/RCTEventDispatcher.h>
+#import <React/RCTViewManager.h>
+#import <React/UIView+React.h>
 #import "AIRMapMarker.h"
-#import "RCTViewManager.h"
 #import "AIRMapCircle.h"
 
 @interface AIRMapCircleManager()

--- a/ios/AirMaps/AIRMapManager.h
+++ b/ios/AirMaps/AIRMapManager.h
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import "RCTViewManager.h"
+#import <React/RCTViewManager.h>
 
 @interface AIRMapManager : RCTViewManager
 

--- a/ios/AirMaps/AIRMapManager.m
+++ b/ios/AirMaps/AIRMapManager.m
@@ -7,19 +7,18 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import "RCTViewManager.h"
 #import "AIRMapManager.h"
 
-#import "RCTBridge.h"
-#import "RCTUIManager.h"
-#import "RCTConvert+CoreLocation.h"
-#import "RCTConvert+MapKit.h"
-#import "RCTEventDispatcher.h"
+#import <React/RCTBridge.h>
+#import <React/RCTUIManager.h>
+#import <React/RCTConvert.h>
+#import <React/RCTConvert+CoreLocation.h>
+#import <React/RCTConvert+MapKit.h>
+#import <React/RCTEventDispatcher.h>
+#import <React/RCTViewManager.h>
+#import <React/UIView+React.h>
 #import "AIRMap.h"
-#import "UIView+React.h"
 #import "AIRMapMarker.h"
-#import "RCTViewManager.h"
-#import "RCTConvert.h"
 #import "AIRMapPolyline.h"
 #import "AIRMapPolygon.h"
 #import "AIRMapCircle.h"
@@ -307,7 +306,7 @@ RCT_EXPORT_METHOD(takeSnapshot:(nonnull NSNumber *)reactTag
                       UIImage *compositeImage = UIGraphicsGetImageFromCurrentImageContext();
 
                       NSData *data;
-                      if ([format isEqualToString:@"png"]) {                      
+                      if ([format isEqualToString:@"png"]) {
                           data = UIImagePNGRepresentation(compositeImage);
                       }
                       else if([format isEqualToString:@"jpg"]) {
@@ -325,7 +324,7 @@ RCT_EXPORT_METHOD(takeSnapshot:(nonnull NSNumber *)reactTag
 
                           // In the initial (iOS only) implementation of takeSnapshot,
                           // both the uri and the base64 encoded string were returned.
-                          // Returning both is rarely useful and in fact causes a 
+                          // Returning both is rarely useful and in fact causes a
                           // performance penalty when only the file URI is desired.
                           // In that case the base64 encoded string was always marshalled
                           // over the JS-bridge (which is quite slow).

--- a/ios/AirMaps/AIRMapMarker.h
+++ b/ios/AirMaps/AIRMapMarker.h
@@ -13,8 +13,8 @@
 #import <MapKit/MapKit.h>
 #import <UIKit/UIKit.h>
 
-#import "RCTConvert+MapKit.h"
-#import "RCTComponent.h"
+#import <React/RCTConvert+MapKit.h>
+#import <React/RCTComponent.h>
 #import "AIRMap.h"
 #import "SMCalloutView.h"
 

--- a/ios/AirMaps/AIRMapMarker.m
+++ b/ios/AirMaps/AIRMapMarker.m
@@ -9,11 +9,11 @@
 
 #import "AIRMapMarker.h"
 
-#import "RCTEventDispatcher.h"
-#import "UIView+React.h"
-#import "RCTBridge.h"
-#import "RCTUtils.h"
-#import "RCTImageLoader.h"
+#import <React/RCTBridge.h>
+#import <React/RCTEventDispatcher.h>
+#import <React/RCTImageLoader.h>
+#import <React/RCTUtils.h>
+#import <React/UIView+React.h>
 
 @implementation AIREmptyCalloutBackgroundView
 @end
@@ -232,7 +232,7 @@
 - (void)setPinColor:(UIColor *)pinColor
 {
     _pinColor = pinColor;
-    
+
     if ([_pinView respondsToSelector:@selector(setPinTintColor:)]) {
         _pinView.pinTintColor = _pinColor;
     }

--- a/ios/AirMaps/AIRMapMarkerManager.h
+++ b/ios/AirMaps/AIRMapMarkerManager.h
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import "RCTViewManager.h"
+#import <React/RCTViewManager.h>
 
 @interface AIRMapMarkerManager : RCTViewManager
 

--- a/ios/AirMaps/AIRMapMarkerManager.m
+++ b/ios/AirMaps/AIRMapMarkerManager.m
@@ -9,9 +9,9 @@
 
 #import "AIRMapMarkerManager.h"
 
-#import "RCTUIManager.h"
-#import "RCTConvert+CoreLocation.h"
-#import "UIView+React.h"
+#import <React/RCTConvert+CoreLocation.h>
+#import <React/RCTUIManager.h>
+#import <React/UIView+React.h>
 #import "AIRMapMarker.h"
 
 @interface AIRMapMarkerManager () <MKMapViewDelegate>

--- a/ios/AirMaps/AIRMapPolygon.h
+++ b/ios/AirMaps/AIRMapPolygon.h
@@ -8,11 +8,11 @@
 #import <MapKit/MapKit.h>
 #import <UIKit/UIKit.h>
 
-#import "RCTConvert+MapKit.h"
-#import "RCTComponent.h"
+#import <React/RCTComponent.h>
+#import <React/RCTConvert+MapKit.h>
+#import <React/RCTView.h>
 #import "AIRMapCoordinate.h"
 #import "AIRMap.h"
-#import "RCTView.h"
 
 
 

--- a/ios/AirMaps/AIRMapPolygon.m
+++ b/ios/AirMaps/AIRMapPolygon.m
@@ -4,7 +4,7 @@
 //
 
 #import "AIRMapPolygon.h"
-#import "UIView+React.h"
+#import <React/UIView+React.h>
 
 
 @implementation AIRMapPolygon {

--- a/ios/AirMaps/AIRMapPolygonManager.h
+++ b/ios/AirMaps/AIRMapPolygonManager.h
@@ -3,7 +3,7 @@
 // Copyright (c) 2015 Facebook. All rights reserved.
 //
 
-#import "RCTViewManager.h"
+#import <React/RCTViewManager.h>
 
 
 @interface AIRMapPolygonManager : RCTViewManager

--- a/ios/AirMaps/AIRMapPolygonManager.m
+++ b/ios/AirMaps/AIRMapPolygonManager.m
@@ -9,14 +9,14 @@
 
 #import "AIRMapPolygonManager.h"
 
-#import "RCTBridge.h"
-#import "RCTConvert.h"
+#import <React/RCTBridge.h>
+#import <React/RCTConvert.h>
+#import <React/RCTConvert+CoreLocation.h>
+#import <React/RCTEventDispatcher.h>
+#import <React/RCTViewManager.h>
+#import <React/UIView+React.h>
 #import "RCTConvert+MoreMapKit.h"
-#import "RCTConvert+CoreLocation.h"
-#import "RCTEventDispatcher.h"
-#import "UIView+React.h"
 #import "AIRMapMarker.h"
-#import "RCTViewManager.h"
 #import "AIRMapPolygon.h"
 
 @interface AIRMapPolygonManager()

--- a/ios/AirMaps/AIRMapPolyline.h
+++ b/ios/AirMaps/AIRMapPolyline.h
@@ -8,11 +8,11 @@
 #import <MapKit/MapKit.h>
 #import <UIKit/UIKit.h>
 
-#import "RCTConvert+MapKit.h"
-#import "RCTComponent.h"
+#import <React/RCTConvert+MapKit.h>
+#import <React/RCTComponent.h>
+#import <React/RCTView.h>
 #import "AIRMapCoordinate.h"
 #import "AIRMap.h"
-#import "RCTView.h"
 
 
 @interface AIRMapPolyline: MKAnnotationView <MKOverlay>

--- a/ios/AirMaps/AIRMapPolyline.m
+++ b/ios/AirMaps/AIRMapPolyline.m
@@ -4,7 +4,7 @@
 //
 
 #import "AIRMapPolyline.h"
-#import "UIView+React.h"
+#import <React/UIView+React.h>
 
 
 @implementation AIRMapPolyline {

--- a/ios/AirMaps/AIRMapPolylineManager.h
+++ b/ios/AirMaps/AIRMapPolylineManager.h
@@ -3,7 +3,7 @@
 // Copyright (c) 2015 Facebook. All rights reserved.
 //
 
-#import "RCTViewManager.h"
+#import <React/RCTViewManager.h>
 
 
 @interface AIRMapPolylineManager : RCTViewManager

--- a/ios/AirMaps/AIRMapPolylineManager.m
+++ b/ios/AirMaps/AIRMapPolylineManager.m
@@ -9,14 +9,14 @@
 
 #import "AIRMapPolylineManager.h"
 
-#import "RCTBridge.h"
-#import "RCTConvert.h"
-#import "RCTConvert+CoreLocation.h"
+#import <React/RCTBridge.h>
+#import <React/RCTConvert.h>
+#import <React/RCTConvert+CoreLocation.h>
+#import <React/RCTEventDispatcher.h>
+#import <React/RCTViewManager.h>
+#import <React/UIView+React.h>
 #import "RCTConvert+MoreMapKit.h"
-#import "RCTEventDispatcher.h"
-#import "UIView+React.h"
 #import "AIRMapMarker.h"
-#import "RCTViewManager.h"
 #import "AIRMapPolyline.h"
 
 @interface AIRMapPolylineManager()

--- a/ios/AirMaps/AIRMapUrlTile.h
+++ b/ios/AirMaps/AIRMapUrlTile.h
@@ -10,11 +10,11 @@
 #import <MapKit/MapKit.h>
 #import <UIKit/UIKit.h>
 
-#import "RCTConvert+MapKit.h"
-#import "RCTComponent.h"
+#import <React/RCTConvert+MapKit.h>
+#import <React/RCTComponent.h>
+#import <React/RCTView.h>
 #import "AIRMapCoordinate.h"
 #import "AIRMap.h"
-#import "RCTView.h"
 
 @interface AIRMapUrlTile : MKAnnotationView <MKOverlay>
 

--- a/ios/AirMaps/AIRMapUrlTile.m
+++ b/ios/AirMaps/AIRMapUrlTile.m
@@ -7,7 +7,7 @@
 //
 
 #import "AIRMapUrlTile.h"
-#import "UIView+React.h"
+#import <React/UIView+React.h>
 
 @implementation AIRMapUrlTile {
     BOOL _urlTemplateSet;

--- a/ios/AirMaps/AIRMapUrlTileManager.h
+++ b/ios/AirMaps/AIRMapUrlTileManager.h
@@ -7,7 +7,7 @@
 //
 
 
-#import "RCTViewManager.h"
+#import <React/RCTViewManager.h>
 
 @interface AIRMapUrlTileManager : RCTViewManager
 

--- a/ios/AirMaps/AIRMapUrlTileManager.m
+++ b/ios/AirMaps/AIRMapUrlTileManager.m
@@ -6,13 +6,13 @@
 //  Copyright © 2016. All rights reserved.
 //
 
-#import "RCTBridge.h"
-#import "RCTConvert.h"
-#import "RCTConvert+CoreLocation.h"
-#import "RCTEventDispatcher.h"
-#import "UIView+React.h"
+#import <React/RCTBridge.h>
+#import <React/RCTConvert.h>
+#import <React/RCTConvert+CoreLocation.h>
+#import <React/RCTEventDispatcher.h>
+#import <React/RCTViewManager.h>
+#import <React/UIView+React.h>
 #import "AIRMapMarker.h"
-#import "RCTViewManager.h"
 #import "AIRMapUrlTile.h"
 
 #import "AIRMapUrlTileManager.h"
@@ -35,4 +35,3 @@ RCT_EXPORT_MODULE()
 RCT_EXPORT_VIEW_PROPERTY(urlTemplate, NSString)
 
 @end
-

--- a/ios/AirMaps/RCTConvert+MoreMapKit.h
+++ b/ios/AirMaps/RCTConvert+MoreMapKit.h
@@ -5,7 +5,7 @@
 
 #import <CoreLocation/CoreLocation.h>
 #import <MapKit/MapKit.h>
-#import "RCTConvert.h"
+#import <React/RCTConvert.h>
 
 @interface RCTConvert (MoreMapKit)
 

--- a/ios/AirMaps/RCTConvert+MoreMapKit.m
+++ b/ios/AirMaps/RCTConvert+MoreMapKit.m
@@ -4,9 +4,9 @@
 //
 
 #import "RCTConvert+MoreMapKit.h"
-#import "AIRMapCoordinate.h"
-#import "RCTConvert+CoreLocation.h"
 
+#import <React/RCTConvert+CoreLocation.h>
+#import "AIRMapCoordinate.h"
 
 @implementation RCTConvert (MoreMapKit)
 

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "mapkit"
   ],
   "peerDependencies": {
-    "react": ">=15.3.1",
-    "react-native": ">=0.35"
+    "react": ">=15.4.0",
+    "react-native": ">=0.40"
   },
   "devDependencies": {
     "babel-eslint": "^6.1.2",


### PR DESCRIPTION
React Native 0.40 (coming soon) changes the way its iOS headers should be imported. The headers are now under a directory called "React" that is in the compiler's include path, hence the new import style.

On the JS side, RN 0.40 now peer-depends on React 15.4.x which moved SyntheticEvent from `react/lib` to deep inside `react-native`, so update that import as well.

Test Plan: Follow the setup instructions (https://github.com/airbnb/react-native-maps/blob/master/docs/examples-setup.md) and run the iOS explorer app (notably verify that it compiles). Here it is running, nothing special, it just works as expected:

![screenshot 2016-12-30 21 33 42](https://cloud.githubusercontent.com/assets/379606/21576093/d243c59e-ced8-11e6-9cdc-6a899ef2e811.png)
