### PR TITLE
Fixed issue #751.

### DIFF
--- a/ios/AirMaps/AIRMapManager.m
+++ b/ios/AirMaps/AIRMapManager.m
@@ -158,7 +158,9 @@ RCT_EXPORT_METHOD(fitToElements:(nonnull NSNumber *)reactTag
         } else {
             AIRMap *mapView = (AIRMap *)view;
             // TODO(lmr): we potentially want to include overlays here... and could concat the two arrays together.
-            [mapView showAnnotations:mapView.annotations animated:animated];
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+                [mapView showAnnotations:mapView.annotations animated:animated];
+            });
         }
     }];
 }


### PR DESCRIPTION
Fixed issue #751 

When `fitToElements` is set to `true` from `ComponentDidMount` it causes a behaviour where callouts does not appear sometimes and if appear they are sometimes overlapped by other markers.