### PR TITLE
Add Android build tools 23.0.3 instructions

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -61,7 +61,12 @@ After your `Podfile` is setup properly, run `pod install`.
    require('react-native-maps');`
 
 ## Android
-
+1. Install SDK Tools 23.0.3
+   >You will need to perform this step whether or not you use "react-native link"
+   
+   ```
+   android update sdk --no-ui --all --filter build-tools-23.0.3
+   ```
 1. In your `android/app/build.gradle` add:
    >This step is not necessary if you ran "react-native link"
 


### PR DESCRIPTION
Currently React Native documentation recommends Android build tools 23.0.1 (https://facebook.github.io/react-native/docs/getting-started.html) however react-native-maps also requires 23.0.3 to be installed.

I've added instructions for installing android sdk tools 23.0.3 from command line. 

The build error if you don't have 23.0.3 installed is

```
A problem occurred configuring project ':app'.
> A problem occurred configuring project ':react-native-maps'.
   > Failed to notify project evaluation listener.
      > failed to find Build Tools revision 23.0.3
      > failed to find Build Tools revision 23.0.3
```