### PR TITLE
Add Android SDK Build tools 23.03 to troubleshooting

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -189,6 +189,7 @@ You have to link dependencies with rnpm and re-run the build:
     - Extras / Google Play services
     - Extras / Google Repository
     - Android 6.0 (API 23) / Google APIs Intel x86 Atom System Image Rev. 19
+    - Android SDK Build-tools 23.0.3 
 1. Check manual installation steps if you didn't run "react-native link"
 1. Go to [Google API Console](https://console.developers.google.com/flows/enableapi?apiid=maps_android_backend) and select your project, or create one.
 Then, once enabled, select `Go to credentials`.


### PR DESCRIPTION
This adds Android SDK Build-tools 23.0.3 to the troubleshooting section for Android. This is required because react-native documentation (https://facebook.github.io/react-native/docs/getting-started.html) only specifies a requirement of Build-tools 23.0.1.
The build error if you don't have 23.0.3 installed is

```
A problem occurred configuring project ':app'.
> A problem occurred configuring project ':react-native-maps'.
   > Failed to notify project evaluation listener.
      > failed to find Build Tools revision 23.0.3
      > failed to find Build Tools revision 23.0.3
```