### PR TITLE
Add 'Use Host GPU' troubleshooting step for Android

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -211,3 +211,5 @@ Enter the name of the API key and create it.
    gradlew clean
    cd ..
   ```
+  
+1. If you are using Android Virtual Devices (AVD), ensure that `Use Host GPU` is checked in the settings for your virtual device.


### PR DESCRIPTION
Added troubleshooting step for enabling Use Host GPU checkbox in AVD settings. It appears that Google Maps requires Open GL to be enabled and working on devices for it to draw the map. See https://github.com/airbnb/react-native-maps/issues/942