### PR TITLE
Fixed issue #286.

### DIFF
--- a/ios/AirMaps/AIRMapMarker.h
+++ b/ios/AirMaps/AIRMapMarker.h
@@ -48,6 +48,7 @@
 - (BOOL)shouldShowCalloutView;
 - (void)showCalloutView;
 - (void)hideCalloutView;
+- (void)addTapGestureRecognizer;
 
 @end
 

--- a/ios/AirMaps/AIRMapMarker.m
+++ b/ios/AirMaps/AIRMapMarker.m
@@ -71,6 +71,7 @@
         // In this case, we want to render a platform "default" marker.
         if (_pinView == nil) {
             _pinView = [[MKPinAnnotationView alloc] initWithAnnotation:self reuseIdentifier: nil];
+            [self addGestureRecognizerToView:_pinView];
             _pinView.annotation = self;
         }
 
@@ -165,6 +166,56 @@
                                          inView:annotationView
                               constrainedToView:self.map
                                        animated:YES];
+}
+
+#pragma mark - Tap Gesture & Events.
+
+- (void)addTapGestureRecognizer {
+    [self addGestureRecognizerToView:nil];
+}
+
+- (void)addGestureRecognizerToView:(UIView *)view {
+    if (!view) {
+        view = self;
+    }
+    UITapGestureRecognizer *tapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(_handleTap:)];
+    // setting this to NO allows the parent MapView to continue receiving marker selection events
+    tapGestureRecognizer.cancelsTouchesInView = NO;
+    [view addGestureRecognizer:tapGestureRecognizer];
+}
+
+- (void)_handleTap:(UITapGestureRecognizer *)recognizer {
+    AIRMapMarker *marker = self;
+    if (!marker) return;
+    
+    if (marker.selected) {
+        CGPoint touchPoint = [recognizer locationInView:marker.map.calloutView];
+        if ([marker.map.calloutView hitTest:touchPoint withEvent:nil]) {
+            
+            // the callout got clicked, not the marker
+            id event = @{
+                         @"action": @"callout-press",
+                         };
+            
+            if (marker.onCalloutPress) marker.onCalloutPress(event);
+            if (marker.calloutView && marker.calloutView.onPress) marker.calloutView.onPress(event);
+            if (marker.map.onCalloutPress) marker.map.onCalloutPress(event);
+            return;
+        }
+    }
+    
+    // the actual marker got clicked
+    id event = @{
+                 @"action": @"marker-press",
+                 @"id": marker.identifier ?: @"unknown",
+                 @"coordinate": @{
+                         @"latitude": @(marker.coordinate.latitude),
+                         @"longitude": @(marker.coordinate.longitude)
+                         }
+                 };
+    
+    if (marker.onPress) marker.onPress(event);
+    if (marker.map.onMarkerPress) marker.map.onMarkerPress(event);
 }
 
 - (void)hideCalloutView

--- a/ios/AirMaps/AIRMapMarkerManager.m
+++ b/ios/AirMaps/AIRMapMarkerManager.m
@@ -25,10 +25,7 @@ RCT_EXPORT_MODULE()
 - (UIView *)view
 {
     AIRMapMarker *marker = [AIRMapMarker new];
-    UITapGestureRecognizer *tapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(_handleTap:)];
-    // setting this to NO allows the parent MapView to continue receiving marker selection events
-    tapGestureRecognizer.cancelsTouchesInView = NO;
-    [marker addGestureRecognizer:tapGestureRecognizer];
+    [marker addTapGestureRecognizer];
     marker.bridge = self.bridge;
     return marker;
 }
@@ -76,42 +73,6 @@ RCT_EXPORT_METHOD(hideCallout:(nonnull NSNumber *)reactTag)
             [(AIRMapMarker *) view hideCalloutView];
         }
     }];
-}
-
-#pragma mark - Events
-
-- (void)_handleTap:(UITapGestureRecognizer *)recognizer {
-    AIRMapMarker *marker = (AIRMapMarker *)recognizer.view;
-    if (!marker) return;
-
-    if (marker.selected) {
-        CGPoint touchPoint = [recognizer locationInView:marker.map.calloutView];
-        if ([marker.map.calloutView hitTest:touchPoint withEvent:nil]) {
-
-            // the callout got clicked, not the marker
-            id event = @{
-                    @"action": @"callout-press",
-            };
-
-            if (marker.onCalloutPress) marker.onCalloutPress(event);
-            if (marker.calloutView && marker.calloutView.onPress) marker.calloutView.onPress(event);
-            if (marker.map.onCalloutPress) marker.map.onCalloutPress(event);
-            return;
-        }
-    }
-
-    // the actual marker got clicked
-    id event = @{
-            @"action": @"marker-press",
-            @"id": marker.identifier ?: @"unknown",
-            @"coordinate": @{
-                    @"latitude": @(marker.coordinate.latitude),
-                    @"longitude": @(marker.coordinate.longitude)
-            }
-    };
-
-    if (marker.onPress) marker.onPress(event);
-    if (marker.map.onMarkerPress) marker.map.onMarkerPress(event);
 }
 
 @end


### PR DESCRIPTION
### Fixed issue #286.

#### Description:
The issue relates to [getAnnotationView](https://github.com/airbnb/react-native-maps/blob/master/ios/AirMaps/AIRMapMarker.m#L68) method.
A tap gesture is added to `AirMapMarker` view in `AirMapMarkerManager` class which listens to tap/press events on annotation view as well as callout view. But when `shouldUsePinView` returns `true`, the annotation view on map is a `MKPinAnnotationView` instead of `AirMapMarker` and there is no tap gesture listener on this MKPinAnnotationView.

#### Fix:
Now the Tap gesture is listened by the `AirMapMarker` class itself and gesture now added to MKPinAnnotationView as well.