### PR TITLE
Sets the map value for the AirMapUrlTile so that it can be updated properly

### DIFF
--- a/ios/AirMaps/AIRMap.m
+++ b/ios/AirMaps/AIRMap.m
@@ -104,6 +104,7 @@ const CGFloat AIRMapZoomBoundBuffer = 0.01;
     } else if ([subview isKindOfClass:[AIRMapCircle class]]) {
         [self addOverlay:(id<MKOverlay>)subview];
     } else if ([subview isKindOfClass:[AIRMapUrlTile class]]) {
+        ((AIRMapUrlTile *)subview).map = self;
         [self addOverlay:(id<MKOverlay>)subview];
     }
     [_reactSubviews insertObject:(UIView *)subview atIndex:(NSUInteger) atIndex];


### PR DESCRIPTION
This addresses issue #991. This should allow for templateURL updates to display properly. 