### PR TITLE
Add id identifier to marker-press event on Android

### DIFF
--- a/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -149,13 +149,16 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
             @Override
             public boolean onMarkerClick(Marker marker) {
                 WritableMap event;
+                AirMapMarker airMapMarker = markerMap.get(marker);
 
                 event = makeClickEventData(marker.getPosition());
                 event.putString("action", "marker-press");
+                event.putString("id", airMapMarker.getIdentifier());
                 manager.pushEvent(view, "onMarkerPress", event);
 
                 event = makeClickEventData(marker.getPosition());
                 event.putString("action", "marker-press");
+                event.putString("id", airMapMarker.getIdentifier());
                 manager.pushEvent(markerMap.get(marker), "onPress", event);
 
                 // Return false to open the callout info window and center on the marker


### PR DESCRIPTION
Currently, on iOS the onMarkerPress callback includes the identifier of the map marker as an `id` property. Google Map markers do not store their identifier. This change aligns both platforms.