### PR TITLE
Create `update-version` script to more easily update version

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,15 +28,12 @@
   },
   "devDependencies": {
     "babel-eslint": "^6.1.2",
-    "commander": "^2.9.0",
-    "dedent": "^0.7.0",
     "eslint": "^3.3.1",
     "eslint-config-airbnb": "^10.0.1",
     "eslint-plugin-import": "^1.14.0",
     "eslint-plugin-jsx-a11y": "^2.1.0",
     "eslint-plugin-prefer-object-spread": "^1.1.0",
-    "eslint-plugin-react": "^6.1.2",
-    "semver": "^5.3.0"
+    "eslint-plugin-react": "^6.1.2"
   },
   "rnpm": {
     "android": {

--- a/package.json
+++ b/package.json
@@ -27,12 +27,15 @@
   },
   "devDependencies": {
     "babel-eslint": "^6.1.2",
+    "commander": "^2.9.0",
+    "dedent": "^0.7.0",
     "eslint": "^3.3.1",
     "eslint-config-airbnb": "^10.0.1",
     "eslint-plugin-import": "^1.14.0",
     "eslint-plugin-jsx-a11y": "^2.1.0",
     "eslint-plugin-prefer-object-spread": "^1.1.0",
-    "eslint-plugin-react": "^6.1.2"
+    "eslint-plugin-react": "^6.1.2",
+    "semver": "^5.3.0"
   },
   "rnpm": {
     "android": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "version": "0.13.0",
   "scripts": {
     "start": "react-native start",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "preversion": "./scripts/update-version.js"
   },
   "repository": {
     "type": "git",

--- a/scripts/update-version.js
+++ b/scripts/update-version.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+
+/*
+
+* Get current npm version.
+* Determine what type of version bump: major, minor, patch
+* Update the files:
+  * package.json
+  * android/gradle.properties
+  * react-native-maps.podspec
+  * react-native-google-maps.podspec
+* Make Git commit.
+* Create Git tag.
+
+*/
+
+// TODO: update eslint-plugin-import so we can configure
+// `import/no-extraneous-dependencies` to allow devDependencies in `scripts/`.
+
+const { exec } = require('child_process');
+// eslint-disable-next-line import/no-extraneous-dependencies
+const commander = require('commander');
+// eslint-disable-next-line import/no-extraneous-dependencies
+const dedent = require('dedent');
+// eslint-disable-next-line import/no-extraneous-dependencies
+const semver = require('semver');
+const pkg = require('../package.json');
+
+const versionTypes = ['major', 'minor', 'patch'];
+const filesToUpdate = [
+  'package.json',
+  'android/gradle.properties',
+  'react-native-maps.podspec',
+  'react-native-google-maps.podspec',
+];
+
+commander
+  .version(pkg.version)
+  .arguments('<versionType>')
+  .action(versionType => {
+    if (!versionTypes.includes(versionType)) {
+      die(dedent`Version type "${versionType}" not recognized.
+                Supported values: ${versionTypes.map(v => `"${v}"`).join(', ')}.`);
+    }
+    bumpVersion(pkg.version, versionType).catch(err => {
+      process.stderr.write(`${err.stack}\n`);
+    });
+  });
+
+commander.parse(process.argv);
+
+function die(message) {
+  process.stderr.write(message);
+  process.exit(1);
+}
+
+function doExec(cmdString) {
+  return new Promise((resolve, reject) => {
+    exec(cmdString, (err, stdout) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve(stdout);
+    });
+  });
+}
+
+function bumpVersion(currentVersion, versionType) {
+  const nextVersion = semver.inc(currentVersion, versionType);
+  process.stdout.write(`Updating version from ${currentVersion} to ${nextVersion}...\n`);
+
+  return Promise.resolve()
+    .then(() => updateFiles(currentVersion, nextVersion))
+    .then(() => createCommit(nextVersion))
+    .then(() => createTag(nextVersion))
+  ;
+}
+
+function updateFiles(currentVersion, nextVersion) {
+  return Promise.all(filesToUpdate.map(relativePath =>
+    updateVersionInFile(currentVersion, nextVersion, relativePath)
+  ));
+}
+
+function createCommit(nextVersion) {
+  return doExec(`git commit -am ${nextVersion}`);
+}
+
+function createTag(nextVersion) {
+  return doExec(`git tag v${nextVersion}`);
+}
+
+function updateVersionInFile(currentVersion, nextVersion, relativePath) {
+  process.stdout.write(`-> ${relativePath}\n`);
+  return doExec(`sed -i '' 's/${
+    escapeDots(currentVersion)
+  }/${
+    escapeDots(nextVersion)
+  }/g' ./${relativePath}`);
+}
+
+function escapeDots(version) {
+  return version.replace(/\./g, '\\.');
+}

--- a/scripts/update-version.js
+++ b/scripts/update-version.js
@@ -1,58 +1,24 @@
 #!/usr/bin/env node
 
-/*
-
-* Get current npm version.
-* Determine what type of version bump: major, minor, patch
-* Update the files:
-  * package.json
-  * android/gradle.properties
-  * react-native-maps.podspec
-  * react-native-google-maps.podspec
-* Make Git commit.
-* Create Git tag.
-
+/**
+ * Script that runs as part of `npm version`. It updates any files that have a
+ * reference to the current package version:
+ *
+ * - android/gradle.properties
+ * - react-native-maps.podspec
+ * - react-native-google-maps.podspec
+ *
+ * And `git add`s them.
 */
 
-// TODO: update eslint-plugin-import so we can configure
-// `import/no-extraneous-dependencies` to allow devDependencies in `scripts/`.
-
 const { exec } = require('child_process');
-// eslint-disable-next-line import/no-extraneous-dependencies
-const commander = require('commander');
-// eslint-disable-next-line import/no-extraneous-dependencies
-const dedent = require('dedent');
-// eslint-disable-next-line import/no-extraneous-dependencies
-const semver = require('semver');
 const pkg = require('../package.json');
 
-const versionTypes = ['major', 'minor', 'patch'];
 const filesToUpdate = [
-  'package.json',
   'android/gradle.properties',
   'react-native-maps.podspec',
   'react-native-google-maps.podspec',
 ];
-
-commander
-  .version(pkg.version)
-  .arguments('<versionType>')
-  .action(versionType => {
-    if (!versionTypes.includes(versionType)) {
-      die(dedent`Version type "${versionType}" not recognized.
-                Supported values: ${versionTypes.map(v => `"${v}"`).join(', ')}.`);
-    }
-    bumpVersion(pkg.version, versionType).catch(err => {
-      process.stderr.write(`${err.stack}\n`);
-    });
-  });
-
-commander.parse(process.argv);
-
-function die(message) {
-  process.stderr.write(message);
-  process.exit(1);
-}
 
 function doExec(cmdString) {
   return new Promise((resolve, reject) => {
@@ -66,33 +32,8 @@ function doExec(cmdString) {
   });
 }
 
-function bumpVersion(currentVersion, versionType) {
-  const nextVersion = semver.inc(currentVersion, versionType);
-  process.stdout.write(`Updating version from ${currentVersion} to ${nextVersion}...\n`);
-
-  return Promise.resolve()
-    .then(() => updateFiles(currentVersion, nextVersion))
-    .then(() => createCommit(nextVersion))
-    .then(() => createTag(nextVersion))
-  ;
-}
-
-function updateFiles(currentVersion, nextVersion) {
-  return Promise.all(filesToUpdate.map(relativePath =>
-    updateVersionInFile(currentVersion, nextVersion, relativePath)
-  ));
-}
-
-function createCommit(nextVersion) {
-  return doExec(`git commit -am ${nextVersion}`);
-}
-
-function createTag(nextVersion) {
-  return doExec(`git tag v${nextVersion}`);
-}
-
 function updateVersionInFile(currentVersion, nextVersion, relativePath) {
-  process.stdout.write(`-> ${relativePath}\n`);
+  process.stdout.write(`• ${relativePath}\n`);
   return doExec(`sed -i '' 's/${
     escapeDots(currentVersion)
   }/${
@@ -103,3 +44,29 @@ function updateVersionInFile(currentVersion, nextVersion, relativePath) {
 function escapeDots(version) {
   return version.replace(/\./g, '\\.');
 }
+
+function run() {
+  const currentVersion = pkg.version;
+  const nextVersion = process.env.npm_package_version;
+
+  Promise.resolve()
+    .then(() => updateFiles(currentVersion, nextVersion))
+    .then(() => gitAdd());
+}
+
+// Tasks
+
+function updateFiles(currentVersion, nextVersion) {
+  process.stdout.write(`Updating ${currentVersion} ➞ ${nextVersion}:\n`);
+  return Promise.all(filesToUpdate.map(relativePath =>
+    updateVersionInFile(currentVersion, nextVersion, relativePath)
+  ));
+}
+
+function gitAdd() {
+  return doExec(`git add ${filesToUpdate.join(' ')}`);
+}
+
+// Do it.
+
+run();


### PR DESCRIPTION
Similar to `npm version`, but updates the version number in all the
files we need to.

Usage:

    ./scripts/update-version.js [major|minor|patch]

It will:

* Get current npm version.
* Determine what type of version bump: major, minor, patch
* Update the files:
  * package.json
  * android/gradle.properties
  * react-native-maps.podspec
  * react-native-google-maps.podspec
* Make Git commit.
* Create Git tag.

to: @lelandrichardson @gilbox 
cc: @ljharb 