### PR TITLE
[iOS] Added onPress support for Polygons on Google Maps

### DIFF
--- a/components/MapPolygon.js
+++ b/components/MapPolygon.js
@@ -38,6 +38,12 @@ const propTypes = {
   onPress: PropTypes.func,
 
   /**
+   * Boolean to allow a polygon to be tappable and use the
+   * onPress function
+   */
+  tappable: PropTypes.bool,
+
+  /**
    * The stroke width to use for the path.
    */
   strokeWidth: PropTypes.number,

--- a/example/examples/EventListener.js
+++ b/example/examples/EventListener.js
@@ -130,6 +130,7 @@ class EventListener extends React.Component {
           <MapView.Polygon
             fillColor={'rgba(255,0,0,0.3)'}
             onPress={this.recordEvent('Polygon::onPress')}
+            tappable
             coordinates={[{
               latitude: LATITUDE + (LATITUDE_DELTA / 5),
               longitude: LONGITUDE + (LONGITUDE_DELTA / 4),

--- a/example/ios/AirMapsExplorer.xcodeproj/project.pbxproj
+++ b/example/ios/AirMapsExplorer.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		21E6570C1D77591A00B75EE5 /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 21E6570B1D77591A00B75EE5 /* MobileCoreServices.framework */; };
 		21E6570E1D77591F00B75EE5 /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 21E6570D1D77591F00B75EE5 /* MapKit.framework */; };
 		21E657101D77594C00B75EE5 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 21E6570F1D77594C00B75EE5 /* AudioToolbox.framework */; };
+		5647FBD81E47A82C0054FF00 /* AIRGMSPolygon.m in Sources */ = {isa = PBXBuildFile; fileRef = 5647FBD71E47A82C0054FF00 /* AIRGMSPolygon.m */; };
 		8620CC871DBD814A00B79BFE /* AIRGMSMarker.m in Sources */ = {isa = PBXBuildFile; fileRef = 8620CC6E1DBD814A00B79BFE /* AIRGMSMarker.m */; };
 		8620CC881DBD814A00B79BFE /* AIRGoogleMap.m in Sources */ = {isa = PBXBuildFile; fileRef = 8620CC701DBD814A00B79BFE /* AIRGoogleMap.m */; };
 		8620CC891DBD814A00B79BFE /* AIRGoogleMapCallout.m in Sources */ = {isa = PBXBuildFile; fileRef = 8620CC721DBD814A00B79BFE /* AIRGoogleMapCallout.m */; };
@@ -116,6 +117,8 @@
 		21E6570B1D77591A00B75EE5 /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
 		21E6570D1D77591F00B75EE5 /* MapKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MapKit.framework; path = System/Library/Frameworks/MapKit.framework; sourceTree = SDKROOT; };
 		21E6570F1D77594C00B75EE5 /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
+		5647FBD61E47A82C0054FF00 /* AIRGMSPolygon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIRGMSPolygon.h; sourceTree = "<group>"; };
+		5647FBD71E47A82C0054FF00 /* AIRGMSPolygon.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AIRGMSPolygon.m; sourceTree = "<group>"; };
 		8620CC6D1DBD814A00B79BFE /* AIRGMSMarker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIRGMSMarker.h; sourceTree = "<group>"; };
 		8620CC6E1DBD814A00B79BFE /* AIRGMSMarker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AIRGMSMarker.m; sourceTree = "<group>"; };
 		8620CC6F1DBD814A00B79BFE /* AIRGoogleMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIRGoogleMap.h; sourceTree = "<group>"; };
@@ -293,6 +296,8 @@
 			isa = PBXGroup;
 			children = (
 				8620CC6D1DBD814A00B79BFE /* AIRGMSMarker.h */,
+				5647FBD61E47A82C0054FF00 /* AIRGMSPolygon.h */,
+				5647FBD71E47A82C0054FF00 /* AIRGMSPolygon.m */,
 				8620CC6E1DBD814A00B79BFE /* AIRGMSMarker.m */,
 				8620CC6F1DBD814A00B79BFE /* AIRGoogleMap.h */,
 				8620CC701DBD814A00B79BFE /* AIRGoogleMap.m */,
@@ -510,6 +515,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8620CC891DBD814A00B79BFE /* AIRGoogleMapCallout.m in Sources */,
+				5647FBD81E47A82C0054FF00 /* AIRGMSPolygon.m in Sources */,
 				8620CC8D1DBD814A00B79BFE /* AIRGoogleMapMarkerManager.m in Sources */,
 				8620CC881DBD814A00B79BFE /* AIRGoogleMap.m in Sources */,
 				2166AB2D1D82EC56007538D7 /* AIRMapCircleManager.m in Sources */,

--- a/ios/AirGoogleMaps/AIRGMSPolygon.h
+++ b/ios/AirGoogleMaps/AIRGMSPolygon.h
@@ -1,0 +1,16 @@
+//
+//  AIRGMSPolygon.h
+//  AirMaps
+//
+//  Created by Gerardo Pacheco 02/05/2017.
+//
+
+#import <GoogleMaps/GoogleMaps.h>
+#import "UIView+React.h"
+
+@class AIRGoogleMapPolygon;
+
+@interface AIRGMSPolygon : GMSPolygon
+@property (nonatomic, strong) NSString *identifier;
+@property (nonatomic, copy) RCTBubblingEventBlock onPress;
+@end

--- a/ios/AirGoogleMaps/AIRGMSPolygon.m
+++ b/ios/AirGoogleMaps/AIRGMSPolygon.m
@@ -1,0 +1,12 @@
+//
+//  AIRGMSPolygon.m
+//  AirMaps
+//
+//  Created by Gerardo Pacheco 02/05/2017.
+//
+
+#import "AIRGMSPolygon.h"
+
+@implementation AIRGMSPolygon
+
+@end

--- a/ios/AirGoogleMaps/AIRGoogleMap.h
+++ b/ios/AirGoogleMaps/AIRGoogleMap.h
@@ -40,6 +40,7 @@
 @property (nonatomic, assign) BOOL showsUserLocation;
 
 - (BOOL)didTapMarker:(GMSMarker *)marker;
+- (void)didTapPolygon:(GMSPolygon *)polygon;
 - (void)didTapAtCoordinate:(CLLocationCoordinate2D)coordinate;
 - (void)didLongPressAtCoordinate:(CLLocationCoordinate2D)coordinate;
 - (void)didChangeCameraPosition:(GMSCameraPosition *)position;

--- a/ios/AirGoogleMaps/AIRGoogleMap.m
+++ b/ios/AirGoogleMaps/AIRGoogleMap.m
@@ -170,6 +170,16 @@ id regionAsJSON(MKCoordinateRegion region) {
   return NO;
 }
 
+- (void)didTapPolygon:(GMSOverlay *)polygon {
+    AIRGMSPolygon *airPolygon = (AIRGMSPolygon *)polygon;
+
+    id event = @{@"action": @"polygon-press",
+                 @"id": airPolygon.identifier ?: @"unknown",
+                 };
+
+    if (airPolygon.onPress) airPolygon.onPress(event);
+}
+
 - (void)didTapAtCoordinate:(CLLocationCoordinate2D)coordinate {
   if (!self.onPress) return;
   self.onPress([self eventFromCoordinate:coordinate]);

--- a/ios/AirGoogleMaps/AIRGoogleMapManager.m
+++ b/ios/AirGoogleMaps/AIRGoogleMapManager.m
@@ -202,6 +202,11 @@ RCT_EXPORT_METHOD(takeSnapshot:(nonnull NSNumber *)reactTag
   return [googleMapView didTapMarker:marker];
 }
 
+- (void)mapView:(GMSMapView *)mapView didTapOverlay:(GMSPolygon *)polygon {
+  AIRGoogleMap *googleMapView = (AIRGoogleMap *)mapView;
+  [googleMapView didTapPolygon:polygon];
+}
+
 - (void)mapView:(GMSMapView *)mapView didTapAtCoordinate:(CLLocationCoordinate2D)coordinate {
   AIRGoogleMap *googleMapView = (AIRGoogleMap *)mapView;
   [googleMapView didTapAtCoordinate:coordinate];

--- a/ios/AirGoogleMaps/AIRGoogleMapPolygon.h
+++ b/ios/AirGoogleMaps/AIRGoogleMapPolygon.h
@@ -5,18 +5,24 @@
 //
 
 #import <GoogleMaps/GoogleMaps.h>
+#import <React/RCTBridge.h>
+#import "AIRGMSPolygon.h"
 #import "AIRMapCoordinate.h"
 
 @interface AIRGoogleMapPolygon : UIView
 
-@property (nonatomic, strong) GMSPolygon *polygon;
+@property (nonatomic, weak) RCTBridge *bridge;
+@property (nonatomic, strong) NSString *identifier;
+@property (nonatomic, strong) AIRGMSPolygon *polygon;
 @property (nonatomic, strong) NSArray<AIRMapCoordinate *> *coordinates;
 @property (nonatomic, strong) NSArray<NSArray<AIRMapCoordinate *> *> *holes;
+@property (nonatomic, copy) RCTBubblingEventBlock onPress;
 
 @property (nonatomic, assign) UIColor *fillColor;
 @property (nonatomic, assign) double strokeWidth;
 @property (nonatomic, assign) UIColor *strokeColor;
 @property (nonatomic, assign) BOOL geodesic;
 @property (nonatomic, assign) int zIndex;
+@property (nonatomic, assign) BOOL tappable;
 
 @end

--- a/ios/AirGoogleMaps/AIRGoogleMapPolygon.m
+++ b/ios/AirGoogleMaps/AIRGoogleMapPolygon.m
@@ -5,6 +5,7 @@
 //
 
 #import "AIRGoogleMapPolygon.h"
+#import "AIRGMSPolygon.h"
 #import <GoogleMaps/GoogleMaps.h>
 
 @implementation AIRGoogleMapPolygon
@@ -12,7 +13,7 @@
 - (instancetype)init
 {
   if (self = [super init]) {
-    _polygon = [[GMSPolygon alloc] init];
+    _polygon = [[AIRGMSPolygon alloc] init];
   }
 
   return self;
@@ -80,6 +81,16 @@
 {
   _zIndex = zIndex;
   _polygon.zIndex = zIndex;
+}
+
+-(void)setTappable:(BOOL)tappable
+{
+  _tappable = tappable;
+  _polygon.tappable = tappable;
+}
+
+- (void)setOnPress:(RCTBubblingEventBlock)onPress {
+  _polygon.onPress = onPress;
 }
 
 @end

--- a/ios/AirGoogleMaps/AIRGoogleMapPolygonManager.m
+++ b/ios/AirGoogleMaps/AIRGoogleMapPolygonManager.m
@@ -25,6 +25,7 @@ RCT_EXPORT_MODULE()
 - (UIView *)view
 {
   AIRGoogleMapPolygon *polygon = [AIRGoogleMapPolygon new];
+  polygon.bridge = self.bridge;
   return polygon;
 }
 
@@ -35,5 +36,7 @@ RCT_EXPORT_VIEW_PROPERTY(strokeWidth, double)
 RCT_EXPORT_VIEW_PROPERTY(strokeColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(geodesic, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(zIndex, int)
+RCT_EXPORT_VIEW_PROPERTY(tappable, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(onPress, RCTBubblingEventBlock)
 
 @end


### PR DESCRIPTION
Related with https://github.com/airbnb/react-native-maps/issues/982 the onPress functionality was missing for Polygons using Google Maps on iOS.

This PR adds the missing functionality mentioned above with a new property `tappable` to enable tab events on Polygons (Overlays) since this is disabled by default (see [this](https://developers.google.com/maps/documentation/ios-sdk/reference/interface_g_m_s_overlay.html#a45005ec17da8c14bd1978f5cf19d91c7))

You can test the onPress event in the example app under the 'Events (incomplete)' section:

![reactnativemaps2](https://cloud.githubusercontent.com/assets/4885740/22629158/242dd06e-ebe1-11e6-86a1-3d00fb90d26b.gif)
