### PR TITLE
Improve documentation for fitToCoordinates

### DIFF
--- a/docs/mapview.md
+++ b/docs/mapview.md
@@ -56,7 +56,7 @@
 |---|---|---|
 | `animateToRegion` | `region: Region`, `duration: Number` |
 | `animateToCoordinate` | `coordinate: LatLng`, `duration: Number` |
-| `fitToElements` | `animated: Boolean` |
+| `fitToElements` | `animated: Boolean` | If called in `ComponentDidMount` in android, it will cause an exception. It is recommended to be called in `onLayout` event from the MapView component. 
 | `fitToSuppliedMarkers` | `markerIDs: String[]`, `animated: Boolean` | If you need to use this in `ComponentDidMount`, make sure you put it in a timeout or it will cause performance problems.
 | `fitToCoordinates` | `coordinates: Array<LatLng>, options: { edgePadding: EdgePadding, animated: Boolean }` |
 

--- a/docs/mapview.md
+++ b/docs/mapview.md
@@ -56,9 +56,9 @@
 |---|---|---|
 | `animateToRegion` | `region: Region`, `duration: Number` |
 | `animateToCoordinate` | `coordinate: LatLng`, `duration: Number` |
-| `fitToElements` | `animated: Boolean` | If called in `ComponentDidMount` in android, it will cause an exception. It is recommended to be called in `onLayout` event from the MapView component. 
+| `fitToElements` | `animated: Boolean` | 
 | `fitToSuppliedMarkers` | `markerIDs: String[]`, `animated: Boolean` | If you need to use this in `ComponentDidMount`, make sure you put it in a timeout or it will cause performance problems.
-| `fitToCoordinates` | `coordinates: Array<LatLng>, options: { edgePadding: EdgePadding, animated: Boolean }` |
+| `fitToCoordinates` | `coordinates: Array<LatLng>, options: { edgePadding: EdgePadding, animated: Boolean }` | If called in `ComponentDidMount` in android, it will cause an exception. It is recommended to call it from the MapView `onLayout` event. 
 
 
 


### PR DESCRIPTION
Added this related to #1003 and probably. It is just a comment on the notes of `fitToCoordinates` related to the when is recommended to call this method. Due a crash on android if called from `ComponentDidMount`. 
This could be a temporal solution, till someone (I will try if i find the time for it) investigate why is it crashing the call in android in this specific case.