### PR TITLE
Issue #934 Add customized user location annotation text

### DIFF
--- a/components/MapView.js
+++ b/components/MapView.js
@@ -87,6 +87,15 @@ const propTypes = {
   showsUserLocation: PropTypes.bool,
 
   /**
+   * The title of the annotation for current user location. This only works if
+   * `showsUserLocation` is true.
+   * There is a default value `My Location` set by MapView.
+   *
+   * @platform ios
+   */
+  userLocationAnnotationTitle: PropTypes.string,
+
+  /**
    * If `false` hide the button to move map to the current user's location.
    * Default value is `true`.
    *

--- a/docs/mapview.md
+++ b/docs/mapview.md
@@ -10,6 +10,7 @@
 | `liteMode` | `Boolean` | `false` | Enable lite mode. **Note**: Android only.
 | `mapType` | `String` | `"standard"` | The map type to be displayed. <br/><br/> - standard: standard road map (default)<br/> - satellite: satellite view<br/> - hybrid: satellite view with roads and points of interest overlayed<br/> - terrain: (Android only) topographic view
 | `showsUserLocation` | `Boolean` | `false` | If `true` the app will ask for the user's location. **NOTE**: You need to add `NSLocationWhenInUseUsageDescription` key in Info.plist to enable geolocation, otherwise it is going to *fail silently*!
+| `userLocationAnnotationTitle` | `String` | | The title of the annotation for current user location. This only works if `showsUserLocation` is true. There is a default value `My Location` set by MapView. **Note**: iOS only.
 | `followsUserLocation` | `Boolean` | `false` | If `true` the map will focus on the user's location. This only works if `showsUserLocation` is true and the user has shared their location. **Note**: iOS only.
 | `showsMyLocationButton` | `Boolean` | `true` | `Android only` If `false` hide the button to move map to the current user's location.
 | `showsPointsOfInterest` | `Boolean` | `true` | If `false` points of interest won't be displayed on the map.

--- a/ios/AirMaps/AIRMap.h
+++ b/ios/AirMaps/AIRMap.h
@@ -24,6 +24,7 @@ extern const CGFloat AIRMapZoomBoundBuffer;
 @property (nonatomic, strong) UIImageView *cacheImageView;
 @property (nonatomic, strong) UIView *loadingView;
 
+@property (nonatomic, copy) NSString *userLocationAnnotationTitle;
 @property (nonatomic, assign) BOOL followUserLocation;
 @property (nonatomic, assign) BOOL hasStartedRendering;
 @property (nonatomic, assign) BOOL cacheEnabled;

--- a/ios/AirMaps/AIRMapManager.m
+++ b/ios/AirMaps/AIRMapManager.m
@@ -65,6 +65,7 @@ RCT_EXPORT_MODULE()
 }
 
 RCT_EXPORT_VIEW_PROPERTY(showsUserLocation, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(userLocationAnnotationTitle, NSString)
 RCT_EXPORT_VIEW_PROPERTY(followsUserLocation, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(showsPointsOfInterest, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(showsBuildings, BOOL)
@@ -491,7 +492,10 @@ RCT_EXPORT_METHOD(takeSnapshot:(nonnull NSNumber *)reactTag
 {
     if ([view.annotation isKindOfClass:[AIRMapMarker class]]) {
         [(AIRMapMarker *)view.annotation showCalloutView];
+    } else if ([view.annotation isKindOfClass:[MKUserLocation class]] && mapView.userLocationAnnotationTitle != nil && view.annotation.title != mapView.userLocationAnnotationTitle) {
+        [(MKUserLocation*)view.annotation setTitle: mapView.userLocationAnnotationTitle];
     }
+
 }
 
 - (void)mapView:(AIRMap *)mapView didDeselectAnnotationView:(MKAnnotationView *)view {
@@ -503,6 +507,10 @@ RCT_EXPORT_METHOD(takeSnapshot:(nonnull NSNumber *)reactTag
 - (MKAnnotationView *)mapView:(__unused AIRMap *)mapView viewForAnnotation:(AIRMapMarker *)marker
 {
     if (![marker isKindOfClass:[AIRMapMarker class]]) {
+        if ([marker isKindOfClass:[MKUserLocation class]] && mapView.userLocationAnnotationTitle != nil) {
+            [(MKUserLocation*)marker setTitle: mapView.userLocationAnnotationTitle];
+            return nil;
+        }
         return nil;
     }
 


### PR DESCRIPTION
##### Description

On iOS, the user location annotation has a default and unsettable text `My Location`, as shown in issue #934.

##### Fix

Now you can add `userLocationAnnotationTitle` as a prop to `<MapView />` when `showsUserLocation` is true.

##### Note

I had no prior experience in Objective-C so do let me know if the codes modified are dirty. Any other suggestions on the modified code are also welcome.
