### PR TITLE
fix onSelected event for markers with custom view

### DIFF
--- a/ios/AirMaps/AIRMapMarker.m
+++ b/ios/AirMaps/AIRMapMarker.m
@@ -216,6 +216,8 @@
     
     if (marker.onPress) marker.onPress(event);
     if (marker.map.onMarkerPress) marker.map.onMarkerPress(event);
+    
+    [marker.map selectAnnotation:marker animated:NO];
 }
 
 - (void)hideCalloutView


### PR DESCRIPTION
addresses #436, parts of #553 

Problem: when using markers with a custom subview, `didSelectAnnotation` does not get triggered on tap events, unless you press on the outside edge of the marker (outside the subview but inside the marker)

Solution: 'marker-press' events manually call `selectAnnotation` on the marker's mapview