### PR TITLE
Crash in our App fix

### DIFF
--- a/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -41,6 +41,7 @@ import com.google.android.gms.maps.model.LatLngBounds;
 import com.google.android.gms.maps.model.Marker;
 import com.google.android.gms.maps.model.Polygon;
 import com.google.android.gms.maps.model.Polyline;
+import com.google.android.gms.maps.model.VisibleRegion;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -646,9 +647,12 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
         @Override
         public void run() {
 
-            LatLngBounds bounds = map.getProjection().getVisibleRegion().latLngBounds;
-            if (lastBoundsEmitted == null ||
-                    LatLngBoundsUtils.BoundsAreDifferent(bounds, lastBoundsEmitted)) {
+            Projection projection = map.getProjection();
+            VisibleRegion region = (projection != null) ? projection.getVisibleRegion() : null;
+            LatLngBounds bounds = (region != null) ? region.latLngBounds : null;
+
+            if ((bounds != null) &&
+                (lastBoundsEmitted == null || LatLngBoundsUtils.BoundsAreDifferent(bounds, lastBoundsEmitted))) {
                 LatLng center = map.getCameraPosition().target;
                 lastBoundsEmitted = bounds;
                 eventDispatcher.dispatchEvent(new RegionChangeEvent(getId(), bounds, center, true));


### PR DESCRIPTION
java.lang.NullPointerException: Attempt to invoke virtual method
'com.google.android.gms.maps.Projection
com.google.android.gms.maps.GoogleMap.getProjection()' on a null object
reference
at com.airbnb.android.react.maps.AirMapView$13.run(AirMapView.java:643)
at android.os.Handler.handleCallback(Handler.java:739)
at android.os.Handler.dispatchMessage(Handler.java:95)
at android.os.Looper.loop(Looper.java:135)
at android.app.ActivityThread.main(ActivityThread.java:5289)
at java.lang.reflect.Method.invoke(Native Method)
at java.lang.reflect.Method.invoke(Method.java:372)
at
com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.ja
va:899)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:694)