### PR TITLE
Implements animateToCoordinate to Google Maps iOS

### DIFF
--- a/ios/AirGoogleMaps/AIRGoogleMapManager.m
+++ b/ios/AirGoogleMaps/AIRGoogleMapManager.m
@@ -65,6 +65,22 @@ RCT_EXPORT_VIEW_PROPERTY(onRegionChange, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onRegionChangeComplete, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(mapType, GMSMapViewType)
 
+RCT_EXPORT_METHOD(animateToCoordinate:(nonnull NSNumber *)reactTag
+                  withLocation:(CLLocationCoordinate2D)location
+                  withDuration:(CGFloat)duration)
+{
+  [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+    id view = viewRegistry[reactTag];
+    if (![view isKindOfClass:[AIRGoogleMap class]]) {
+      RCTLogError(@"Invalid view returned from registry, expecting AIRGoogleMap, got: %@", view);
+    } else {
+      [AIRGoogleMap animateWithDuration:duration/1000 animations:^{
+        [(AIRGoogleMap *)view animateToLocation:location];
+      }];
+    }
+  }];
+}
+
 RCT_EXPORT_METHOD(animateToRegion:(nonnull NSNumber *)reactTag
                   withRegion:(MKCoordinateRegion)region
                   withDuration:(CGFloat)duration)


### PR DESCRIPTION
Implements [animateToCoordinate](https://github.com/airbnb/react-native-maps/blob/master/docs/mapview.md#methods) on Google Maps iOS

To see it working, use the follow:

`index.ios.js:`
```jsx
import React, { Component } from 'react';
import {
  AppRegistry,
  StyleSheet,
  Button,
} from 'react-native';
import MapView from 'react-native-maps'

export default class HelloMaps extends Component {
  render() {
    return (
      <MapView ref={component => this.map = component} style={styles.container}
          provider={MapView.PROVIDER_GOOGLE}
      >
        <Button 
          title="Go Sydney" 
          onPress={() => { this.map.animateToCoordinate({latitude: -33.852896, longitude: 151.210291})  }}
        />
      </MapView>
    );
  }
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'flex-end',
    alignItems: 'center',
    backgroundColor: '#F5FCFF',
  },
});

AppRegistry.registerComponent('HelloMaps', () => HelloMaps);
```


