### PR TITLE
[iOS - Google Maps] Fix animateToCoordinate and animateToRegion

### DIFF
--- a/example/examples/DisplayLatLng.js
+++ b/example/examples/DisplayLatLng.js
@@ -43,12 +43,22 @@ class DisplayLatLng extends React.Component {
     this.map.animateToRegion(this.randomRegion());
   }
 
-  randomRegion() {
-    const { region } = this.state;
+  animateRandomCoordinate() {
+    this.map.animateToCoordinate(this.randomCoordinate());
+  }
+
+  randomCoordinate() {
+    const region = this.state.region;
     return {
-      ...this.state.region,
       latitude: region.latitude + ((Math.random() - 0.5) * (region.latitudeDelta / 2)),
       longitude: region.longitude + ((Math.random() - 0.5) * (region.longitudeDelta / 2)),
+    };
+  }
+
+  randomRegion() {
+    return {
+      ...this.state.region,
+      ...this.randomCoordinate(),
     };
   }
 
@@ -74,13 +84,19 @@ class DisplayLatLng extends React.Component {
             onPress={() => this.jumpRandom()}
             style={[styles.bubble, styles.button]}
           >
-            <Text>Jump</Text>
+            <Text style={styles.buttonText}>Jump</Text>
           </TouchableOpacity>
           <TouchableOpacity
             onPress={() => this.animateRandom()}
             style={[styles.bubble, styles.button]}
           >
-            <Text>Animate</Text>
+            <Text style={styles.buttonText}>Animate (Region)</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            onPress={() => this.animateRandomCoordinate()}
+            style={[styles.bubble, styles.button]}
+          >
+            <Text style={styles.buttonText}>Animate (Coordinate)</Text>
           </TouchableOpacity>
         </View>
       </View>
@@ -112,15 +128,19 @@ const styles = StyleSheet.create({
     alignItems: 'stretch',
   },
   button: {
-    width: 80,
-    paddingHorizontal: 12,
+    width: 100,
+    paddingHorizontal: 8,
     alignItems: 'center',
-    marginHorizontal: 10,
+    justifyContent: 'center',
+    marginHorizontal: 5,
   },
   buttonContainer: {
     flexDirection: 'row',
     marginVertical: 20,
     backgroundColor: 'transparent',
+  },
+  buttonText: {
+    textAlign: 'center',
   },
 });
 

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
@@ -76,10 +76,14 @@ RCT_EXPORT_METHOD(animateToRegion:(nonnull NSNumber *)reactTag
     if (![view isKindOfClass:[AIRGoogleMap class]]) {
       RCTLogError(@"Invalid view returned from registry, expecting AIRGoogleMap, got: %@", view);
     } else {
-      [AIRGoogleMap animateWithDuration:duration/1000 animations:^{
-        GMSCameraPosition* camera = [AIRGoogleMap makeGMSCameraPositionFromMap:(AIRGoogleMap *)view andMKCoordinateRegion:region];
-        [(AIRGoogleMap *)view animateToCameraPosition:camera];
-      }];
+      // Core Animation must be used to control the animation's duration
+      // See http://stackoverflow.com/a/15663039/171744
+      [CATransaction begin];
+      [CATransaction setAnimationDuration:duration/1000];
+      AIRGoogleMap *mapView = (AIRGoogleMap *)view;
+      GMSCameraPosition *camera = [AIRGoogleMap makeGMSCameraPositionFromMap:mapView andMKCoordinateRegion:region];
+      [mapView animateToCameraPosition:camera];
+      [CATransaction commit];
     }
   }];
 }

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
@@ -26,6 +26,7 @@
 #import "RCTConvert+MapKit.h"
 
 #import <MapKit/MapKit.h>
+#import <QuartzCore/QuartzCore.h>
 
 static NSString *const RCTMapViewKey = @"MapView";
 
@@ -79,6 +80,23 @@ RCT_EXPORT_METHOD(animateToRegion:(nonnull NSNumber *)reactTag
         GMSCameraPosition* camera = [AIRGoogleMap makeGMSCameraPositionFromMap:(AIRGoogleMap *)view andMKCoordinateRegion:region];
         [(AIRGoogleMap *)view animateToCameraPosition:camera];
       }];
+    }
+  }];
+}
+
+RCT_EXPORT_METHOD(animateToCoordinate:(nonnull NSNumber *)reactTag
+                  withRegion:(CLLocationCoordinate2D)latlng
+                  withDuration:(CGFloat)duration)
+{
+  [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+    id view = viewRegistry[reactTag];
+    if (![view isKindOfClass:[AIRGoogleMap class]]) {
+      RCTLogError(@"Invalid view returned from registry, expecting AIRGoogleMap, got: %@", view);
+    } else {
+      [CATransaction begin];
+      [CATransaction setAnimationDuration:duration/1000];
+      [(AIRGoogleMap *)view animateToLocation:latlng];
+      [CATransaction commit];
     }
   }];
 }


### PR DESCRIPTION
This addresses #955 and #811 by doing the following:

- Add the missing `animateToCoordinate()` for Google Maps on iOS - I just noticed that @peterept recently create #1112 😄 but one issue I found when I was working on it was that UIView animation doesn't work. This means the `duration` argument is ignored. The solution was to use Core Animation, which I found here: http://stackoverflow.com/questions/15662148/controlling-animation-duration-in-google-maps-for-ios/15663039#15663039
- Add a new button to the "Tracking Position" example that uses `animateToCoordinate()`. It's very similar to the existing `animateToRegion()` button but is a useful test.
- Use Core Animation for `animateToRegion()`. This is backwards incompatible because the default duration of 500ms was being ignored before but now works.

Google Maps requires that the QuartzCore framework is linked against the project so I assume it's fine to use `CATransaction`.