### PR TITLE
Use local RCTConvert+MapKit instead of the one in React Native

### DIFF
--- a/example/ios/AirMapsExplorer.xcodeproj/project.pbxproj
+++ b/example/ios/AirMapsExplorer.xcodeproj/project.pbxproj
@@ -25,7 +25,7 @@
 		2166AB341D82EC56007538D7 /* AIRMapPolyline.m in Sources */ = {isa = PBXBuildFile; fileRef = 2166AB121D82EC56007538D7 /* AIRMapPolyline.m */; };
 		2166AB351D82EC56007538D7 /* AIRMapPolylineManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 2166AB141D82EC56007538D7 /* AIRMapPolylineManager.m */; };
 		2166AB361D82EC56007538D7 /* SMCalloutView.m in Sources */ = {isa = PBXBuildFile; fileRef = 2166AB171D82EC56007538D7 /* SMCalloutView.m */; };
-		2166AB3E1D82EC56007538D7 /* RCTConvert+MoreMapKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 2166AB281D82EC56007538D7 /* RCTConvert+MoreMapKit.m */; };
+		2166AB3E1D82EC56007538D7 /* RCTConvert+MapKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 2166AB281D82EC56007538D7 /* RCTConvert+MapKit.m */; };
 		21D346651D933B8C002BAD8A /* AIRMapUrlTile.m in Sources */ = {isa = PBXBuildFile; fileRef = 21D346621D933B8C002BAD8A /* AIRMapUrlTile.m */; };
 		21D346661D933B8C002BAD8A /* AIRMapUrlTileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 21D346641D933B8C002BAD8A /* AIRMapUrlTileManager.m */; };
 		21E6570A1D77591400B75EE5 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 21E657091D77591400B75EE5 /* SystemConfiguration.framework */; };
@@ -106,8 +106,8 @@
 		2166AB141D82EC56007538D7 /* AIRMapPolylineManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AIRMapPolylineManager.m; sourceTree = "<group>"; };
 		2166AB161D82EC56007538D7 /* SMCalloutView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SMCalloutView.h; sourceTree = "<group>"; };
 		2166AB171D82EC56007538D7 /* SMCalloutView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SMCalloutView.m; sourceTree = "<group>"; };
-		2166AB271D82EC56007538D7 /* RCTConvert+MoreMapKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+MoreMapKit.h"; sourceTree = "<group>"; };
-		2166AB281D82EC56007538D7 /* RCTConvert+MoreMapKit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "RCTConvert+MoreMapKit.m"; sourceTree = "<group>"; };
+		2166AB271D82EC56007538D7 /* RCTConvert+MapKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+MapKit.h"; sourceTree = "<group>"; };
+		2166AB281D82EC56007538D7 /* RCTConvert+MapKit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "RCTConvert+MapKit.m"; sourceTree = "<group>"; };
 		21D346611D933B8C002BAD8A /* AIRMapUrlTile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIRMapUrlTile.h; sourceTree = "<group>"; };
 		21D346621D933B8C002BAD8A /* AIRMapUrlTile.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AIRMapUrlTile.m; sourceTree = "<group>"; };
 		21D346631D933B8C002BAD8A /* AIRMapUrlTileManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIRMapUrlTileManager.h; sourceTree = "<group>"; };
@@ -242,8 +242,8 @@
 				21D346631D933B8C002BAD8A /* AIRMapUrlTileManager.h */,
 				21D346641D933B8C002BAD8A /* AIRMapUrlTileManager.m */,
 				2166AB151D82EC56007538D7 /* Callout */,
-				2166AB271D82EC56007538D7 /* RCTConvert+MoreMapKit.h */,
-				2166AB281D82EC56007538D7 /* RCTConvert+MoreMapKit.m */,
+				2166AB271D82EC56007538D7 /* RCTConvert+MapKit.h */,
+				2166AB281D82EC56007538D7 /* RCTConvert+MapKit.m */,
 			);
 			name = AirMaps;
 			path = ../../ios/AirMaps;
@@ -528,7 +528,7 @@
 				8697D6221DBEDE6100DB7D0F /* AIRGoogleMapCircle.m in Sources */,
 				2166AB321D82EC56007538D7 /* AIRMapPolygon.m in Sources */,
 				13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */,
-				2166AB3E1D82EC56007538D7 /* RCTConvert+MoreMapKit.m in Sources */,
+				2166AB3E1D82EC56007538D7 /* RCTConvert+MapKit.m in Sources */,
 				8697D6251DBEE22B00DB7D0F /* AIRGoogleMapCircleManager.m in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
 				86DE6F8B1DCE8543002A5053 /* AIRGoogleMapURLTileManager.m in Sources */,

--- a/ios/AirGoogleMaps/AIRGoogleMap.h
+++ b/ios/AirGoogleMaps/AIRGoogleMap.h
@@ -7,10 +7,10 @@
 
 #import <UIKit/UIKit.h>
 #import <React/RCTComponent.h>
-#import <React/RCTConvert+MapKit.h>
 #import <GoogleMaps/GoogleMaps.h>
 #import <MapKit/MapKit.h>
 #import "AIRGMSMarker.h"
+#import "RCTConvert+MapKit.h"
 
 @interface AIRGoogleMap : GMSMapView
 

--- a/ios/AirGoogleMaps/AIRGoogleMap.m
+++ b/ios/AirGoogleMaps/AIRGoogleMap.m
@@ -13,8 +13,8 @@
 #import "AIRGoogleMapUrlTile.h"
 #import <GoogleMaps/GoogleMaps.h>
 #import <MapKit/MapKit.h>
-#import <React/RCTConvert+MapKit.h>
 #import <React/UIView+React.h>
+#import "RCTConvert+MapKit.h"
 
 id regionAsJSON(MKCoordinateRegion region) {
   return @{

--- a/ios/AirGoogleMaps/AIRGoogleMapManager.m
+++ b/ios/AirGoogleMaps/AIRGoogleMapManager.m
@@ -11,7 +11,6 @@
 #import <React/RCTBridge.h>
 #import <React/RCTUIManager.h>
 #import <React/RCTConvert+CoreLocation.h>
-#import <React/RCTConvert+MapKit.h>
 #import <React/RCTEventDispatcher.h>
 #import <React/RCTViewManager.h>
 #import <React/RCTConvert.h>
@@ -24,6 +23,7 @@
 #import "AIRMapCircle.h"
 #import "SMCalloutView.h"
 #import "AIRGoogleMapMarker.h"
+#import "RCTConvert+MapKit.h"
 
 #import <MapKit/MapKit.h>
 

--- a/ios/AirGoogleMaps/AIRGoogleMapMarkerManager.m
+++ b/ios/AirGoogleMaps/AIRGoogleMapMarkerManager.m
@@ -8,8 +8,8 @@
 #import "AIRGoogleMapMarkerManager.h"
 #import "AIRGoogleMapMarker.h"
 #import <MapKit/MapKit.h>
-#import <React/RCTConvert+MapKit.h>
 #import <React/RCTUIManager.h>
+#import "RCTConvert+MapKit.h"
 
 @implementation AIRGoogleMapMarkerManager
 

--- a/ios/AirGoogleMaps/AIRGoogleMapPolygonManager.m
+++ b/ios/AirGoogleMaps/AIRGoogleMapPolygonManager.m
@@ -11,7 +11,7 @@
 #import <React/RCTEventDispatcher.h>
 #import <React/RCTViewManager.h>
 #import <React/UIView+React.h>
-#import "RCTConvert+MoreMapKit.h"
+#import "RCTConvert+MapKit.h"
 #import "AIRGoogleMapPolygon.h"
 
 @interface AIRGoogleMapPolygonManager()

--- a/ios/AirGoogleMaps/AIRGoogleMapPolylineManager.m
+++ b/ios/AirGoogleMaps/AIRGoogleMapPolylineManager.m
@@ -12,7 +12,7 @@
 #import <React/RCTEventDispatcher.h>
 #import <React/RCTViewManager.h>
 #import <React/UIView+React.h>
-#import "RCTConvert+MoreMapKit.h"
+#import "RCTConvert+MapKit.h"
 #import "AIRGoogleMapPolyline.h"
 
 @interface AIRGoogleMapPolylineManager()

--- a/ios/AirMaps.xcodeproj/project.pbxproj
+++ b/ios/AirMaps.xcodeproj/project.pbxproj
@@ -20,8 +20,8 @@
 		1125B2E41C4AD3DA007D0023 /* AIRMapPolygonManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 1125B2D21C4AD3DA007D0023 /* AIRMapPolygonManager.m */; };
 		1125B2E51C4AD3DA007D0023 /* AIRMapPolyline.m in Sources */ = {isa = PBXBuildFile; fileRef = 1125B2D41C4AD3DA007D0023 /* AIRMapPolyline.m */; };
 		1125B2E61C4AD3DA007D0023 /* AIRMapPolylineManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 1125B2D61C4AD3DA007D0023 /* AIRMapPolylineManager.m */; };
-		1125B2E71C4AD3DA007D0023 /* RCTConvert+MoreMapKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 1125B2D91C4AD3DA007D0023 /* RCTConvert+MoreMapKit.m */; };
 		1125B2F21C4AD445007D0023 /* SMCalloutView.m in Sources */ = {isa = PBXBuildFile; fileRef = 1125B2F11C4AD445007D0023 /* SMCalloutView.m */; };
+		19DABC7F1E7C9D3C00F41150 /* RCTConvert+MapKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 19DABC7E1E7C9D3C00F41150 /* RCTConvert+MapKit.m */; };
 		DA6C26381C9E2AFE0035349F /* AIRMapUrlTile.m in Sources */ = {isa = PBXBuildFile; fileRef = DA6C26371C9E2AFE0035349F /* AIRMapUrlTile.m */; };
 		DA6C263E1C9E324A0035349F /* AIRMapUrlTileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = DA6C263D1C9E324A0035349F /* AIRMapUrlTileManager.m */; };
 /* End PBXBuildFile section */
@@ -65,11 +65,11 @@
 		1125B2D41C4AD3DA007D0023 /* AIRMapPolyline.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AIRMapPolyline.m; path = AirMaps/AIRMapPolyline.m; sourceTree = SOURCE_ROOT; };
 		1125B2D51C4AD3DA007D0023 /* AIRMapPolylineManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AIRMapPolylineManager.h; path = AirMaps/AIRMapPolylineManager.h; sourceTree = SOURCE_ROOT; };
 		1125B2D61C4AD3DA007D0023 /* AIRMapPolylineManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AIRMapPolylineManager.m; path = AirMaps/AIRMapPolylineManager.m; sourceTree = SOURCE_ROOT; };
-		1125B2D81C4AD3DA007D0023 /* RCTConvert+MoreMapKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "RCTConvert+MoreMapKit.h"; path = "AirMaps/RCTConvert+MoreMapKit.h"; sourceTree = SOURCE_ROOT; };
-		1125B2D91C4AD3DA007D0023 /* RCTConvert+MoreMapKit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "RCTConvert+MoreMapKit.m"; path = "AirMaps/RCTConvert+MoreMapKit.m"; sourceTree = SOURCE_ROOT; };
 		1125B2F01C4AD445007D0023 /* SMCalloutView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SMCalloutView.h; path = AirMaps/Callout/SMCalloutView.h; sourceTree = SOURCE_ROOT; };
 		1125B2F11C4AD445007D0023 /* SMCalloutView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SMCalloutView.m; path = AirMaps/Callout/SMCalloutView.m; sourceTree = SOURCE_ROOT; };
 		11FA5C511C4A1296003AC2EE /* libAirMaps.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libAirMaps.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		19DABC7D1E7C9D3C00F41150 /* RCTConvert+MapKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+MapKit.h"; sourceTree = "<group>"; };
+		19DABC7E1E7C9D3C00F41150 /* RCTConvert+MapKit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "RCTConvert+MapKit.m"; sourceTree = "<group>"; };
 		DA6C26361C9E2AFE0035349F /* AIRMapUrlTile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIRMapUrlTile.h; sourceTree = "<group>"; };
 		DA6C26371C9E2AFE0035349F /* AIRMapUrlTile.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AIRMapUrlTile.m; sourceTree = "<group>"; };
 		DA6C263C1C9E324A0035349F /* AIRMapUrlTileManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIRMapUrlTileManager.h; sourceTree = "<group>"; };
@@ -132,11 +132,10 @@
 				1125B2D31C4AD3DA007D0023 /* AIRMapPolyline.h */,
 				1125B2D51C4AD3DA007D0023 /* AIRMapPolylineManager.h */,
 				1125B2D61C4AD3DA007D0023 /* AIRMapPolylineManager.m */,
-				21B6E2D21D99B886007E664F /* AIRMapSnapshot.h */,
 				1125B2F01C4AD445007D0023 /* SMCalloutView.h */,
 				1125B2F11C4AD445007D0023 /* SMCalloutView.m */,
-				1125B2D81C4AD3DA007D0023 /* RCTConvert+MoreMapKit.h */,
-				1125B2D91C4AD3DA007D0023 /* RCTConvert+MoreMapKit.m */,
+				19DABC7D1E7C9D3C00F41150 /* RCTConvert+MapKit.h */,
+				19DABC7E1E7C9D3C00F41150 /* RCTConvert+MapKit.m */,
 				DA6C26361C9E2AFE0035349F /* AIRMapUrlTile.h */,
 				DA6C26371C9E2AFE0035349F /* AIRMapUrlTile.m */,
 				DA6C263C1C9E324A0035349F /* AIRMapUrlTileManager.h */,
@@ -207,10 +206,10 @@
 				1125B2E01C4AD3DA007D0023 /* AIRMapManager.m in Sources */,
 				1125B2E61C4AD3DA007D0023 /* AIRMapPolylineManager.m in Sources */,
 				1125B2DD1C4AD3DA007D0023 /* AIRMapCircle.m in Sources */,
+				19DABC7F1E7C9D3C00F41150 /* RCTConvert+MapKit.m in Sources */,
 				1125B2E51C4AD3DA007D0023 /* AIRMapPolyline.m in Sources */,
 				DA6C263E1C9E324A0035349F /* AIRMapUrlTileManager.m in Sources */,
 				1125B2DA1C4AD3DA007D0023 /* AIRMap.m in Sources */,
-				1125B2E71C4AD3DA007D0023 /* RCTConvert+MoreMapKit.m in Sources */,
 				1125B2DF1C4AD3DA007D0023 /* AIRMapCoordinate.m in Sources */,
 				1125B2F21C4AD445007D0023 /* SMCalloutView.m in Sources */,
 				1125B2E11C4AD3DA007D0023 /* AIRMapMarker.m in Sources */,

--- a/ios/AirMaps/AIRMap.h
+++ b/ios/AirMaps/AIRMap.h
@@ -10,9 +10,9 @@
 #import <MapKit/MapKit.h>
 #import <UIKit/UIKit.h>
 
-#import <React/RCTConvert+MapKit.h>
 #import <React/RCTComponent.h>
 #import "SMCalloutView.h"
+#import "RCTConvert+MapKit.h"
 
 extern const CLLocationDegrees AIRMapDefaultSpan;
 extern const NSTimeInterval AIRMapRegionChangeObserveInterval;

--- a/ios/AirMaps/AIRMapCircle.h
+++ b/ios/AirMaps/AIRMapCircle.h
@@ -8,12 +8,12 @@
 #import <MapKit/MapKit.h>
 #import <UIKit/UIKit.h>
 
-#import <React/RCTConvert+MapKit.h>
 #import <React/RCTComponent.h>
 #import <React/RCTView.h>
 
 #import "AIRMapCoordinate.h"
 #import "AIRMap.h"
+#import "RCTConvert+MapKit.h"
 
 @interface AIRMapCircle: MKAnnotationView <MKOverlay>
 

--- a/ios/AirMaps/AIRMapManager.m
+++ b/ios/AirMaps/AIRMapManager.m
@@ -13,7 +13,6 @@
 #import <React/RCTUIManager.h>
 #import <React/RCTConvert.h>
 #import <React/RCTConvert+CoreLocation.h>
-#import <React/RCTConvert+MapKit.h>
 #import <React/RCTEventDispatcher.h>
 #import <React/RCTViewManager.h>
 #import <React/UIView+React.h>
@@ -25,6 +24,7 @@
 #import "SMCalloutView.h"
 #import "AIRMapUrlTile.h"
 #import "AIRMapSnapshot.h"
+#import "RCTConvert+MapKit.h"
 
 #import <MapKit/MapKit.h>
 

--- a/ios/AirMaps/AIRMapMarker.h
+++ b/ios/AirMaps/AIRMapMarker.h
@@ -13,10 +13,10 @@
 #import <MapKit/MapKit.h>
 #import <UIKit/UIKit.h>
 
-#import <React/RCTConvert+MapKit.h>
 #import <React/RCTComponent.h>
 #import "AIRMap.h"
 #import "SMCalloutView.h"
+#import "RCTConvert+MapKit.h"
 
 @class RCTBridge;
 

--- a/ios/AirMaps/AIRMapPolygon.h
+++ b/ios/AirMaps/AIRMapPolygon.h
@@ -9,10 +9,10 @@
 #import <UIKit/UIKit.h>
 
 #import <React/RCTComponent.h>
-#import <React/RCTConvert+MapKit.h>
 #import <React/RCTView.h>
 #import "AIRMapCoordinate.h"
 #import "AIRMap.h"
+#import "RCTConvert+MapKit.h"
 
 
 

--- a/ios/AirMaps/AIRMapPolygonManager.m
+++ b/ios/AirMaps/AIRMapPolygonManager.m
@@ -15,7 +15,7 @@
 #import <React/RCTEventDispatcher.h>
 #import <React/RCTViewManager.h>
 #import <React/UIView+React.h>
-#import "RCTConvert+MoreMapKit.h"
+#import "RCTConvert+MapKit.h"
 #import "AIRMapMarker.h"
 #import "AIRMapPolygon.h"
 

--- a/ios/AirMaps/AIRMapPolyline.h
+++ b/ios/AirMaps/AIRMapPolyline.h
@@ -8,11 +8,11 @@
 #import <MapKit/MapKit.h>
 #import <UIKit/UIKit.h>
 
-#import <React/RCTConvert+MapKit.h>
 #import <React/RCTComponent.h>
 #import <React/RCTView.h>
 #import "AIRMapCoordinate.h"
 #import "AIRMap.h"
+#import "RCTConvert+MapKit.h"
 
 
 @interface AIRMapPolyline: MKAnnotationView <MKOverlay>

--- a/ios/AirMaps/AIRMapPolylineManager.m
+++ b/ios/AirMaps/AIRMapPolylineManager.m
@@ -15,7 +15,7 @@
 #import <React/RCTEventDispatcher.h>
 #import <React/RCTViewManager.h>
 #import <React/UIView+React.h>
-#import "RCTConvert+MoreMapKit.h"
+#import "RCTConvert+MapKit.h"
 #import "AIRMapMarker.h"
 #import "AIRMapPolyline.h"
 

--- a/ios/AirMaps/AIRMapUrlTile.h
+++ b/ios/AirMaps/AIRMapUrlTile.h
@@ -10,11 +10,11 @@
 #import <MapKit/MapKit.h>
 #import <UIKit/UIKit.h>
 
-#import <React/RCTConvert+MapKit.h>
 #import <React/RCTComponent.h>
 #import <React/RCTView.h>
 #import "AIRMapCoordinate.h"
 #import "AIRMap.h"
+#import "RCTConvert+MapKit.h"
 
 @interface AIRMapUrlTile : MKAnnotationView <MKOverlay>
 

--- a/ios/AirMaps/RCTConvert+MapKit.h
+++ b/ios/AirMaps/RCTConvert+MapKit.h
@@ -7,6 +7,10 @@
 #import <MapKit/MapKit.h>
 #import <React/RCTConvert.h>
 
-@interface RCTConvert (MoreMapKit)
+@interface RCTConvert (MapKit)
+
++ (MKCoordinateSpan)MKCoordinateSpan:(id)json;
++ (MKCoordinateRegion)MKCoordinateRegion:(id)json;
++ (MKMapType)MKMapType:(id)json;
 
 @end

--- a/ios/AirMaps/RCTConvert+MapKit.m
+++ b/ios/AirMaps/RCTConvert+MapKit.m
@@ -3,12 +3,35 @@
 // Copyright (c) 2015 Facebook. All rights reserved.
 //
 
-#import "RCTConvert+MoreMapKit.h"
+#import "RCTConvert+MapKit.h"
 
 #import <React/RCTConvert+CoreLocation.h>
 #import "AIRMapCoordinate.h"
 
-@implementation RCTConvert (MoreMapKit)
+@implementation RCTConvert (MapKit)
+
++ (MKCoordinateSpan)MKCoordinateSpan:(id)json
+{
+  json = [self NSDictionary:json];
+  return (MKCoordinateSpan){
+    [self CLLocationDegrees:json[@"latitudeDelta"]],
+    [self CLLocationDegrees:json[@"longitudeDelta"]]
+  };
+}
+
++ (MKCoordinateRegion)MKCoordinateRegion:(id)json
+{
+  return (MKCoordinateRegion){
+    [self CLLocationCoordinate2D:json],
+    [self MKCoordinateSpan:json]
+  };
+}
+
+RCT_ENUM_CONVERTER(MKMapType, (@{
+  @"standard": @(MKMapTypeStandard),
+  @"satellite": @(MKMapTypeSatellite),
+  @"hybrid": @(MKMapTypeHybrid),
+}), MKMapTypeStandard, integerValue)
 
 // NOTE(lmr):
 // This is a bit of a hack, but I'm using this class to simply wrap


### PR DESCRIPTION
Since https://github.com/facebook/react-native/commit/48f30eca7e3d4c239501de515a7cc35615ed6bd1 RCTConvert+MapKit was removed from React Native so this pulls in the relevant methods and renames `RCTConvert+MoreMapKit` to `RCTConvert+MapKit`. I checked that having these extension defined multiple times doesn't cause issues so this is fully backwards compatible.