### PR TITLE
Fix null activity crash

### DIFF
--- a/android/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
+++ b/android/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
@@ -43,8 +43,6 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
             "none", GoogleMap.MAP_TYPE_NONE
     );
 
-    private ReactContext reactContext;
-
     private final ReactApplicationContext appContext;
 
     protected GoogleMapOptions googleMapOptions;
@@ -61,24 +59,15 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
 
     @Override
     protected AirMapView createViewInstance(ThemedReactContext context) {
-        reactContext = context;
-
-        try {
-            MapsInitializer.initialize(this.appContext);
-        } catch (RuntimeException e) {
-            e.printStackTrace();
-            emitMapError("Map initialize error", "map_init_error");
-        }
-
-        return new AirMapView(context, this.appContext.getCurrentActivity(), this, this.googleMapOptions);
+        return new AirMapView(context, this, googleMapOptions);
     }
 
-    private void emitMapError(String message, String type) {
+    private void emitMapError(ThemedReactContext context, String message, String type) {
         WritableMap error = Arguments.createMap();
         error.putString("message", message);
         error.putString("type", type);
 
-        reactContext
+        context
                 .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
                 .emit("onError", error);
     }
@@ -297,9 +286,9 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
         view.updateExtraData(extraData);
     }
 
-    void pushEvent(View view, String name, WritableMap data) {
-        reactContext.getJSModule(RCTEventEmitter.class)
-                .receiveEvent(view.getId(), name, data);
+    void pushEvent(ThemedReactContext context, View view, String name, WritableMap data) {
+        context.getJSModule(RCTEventEmitter.class)
+            .receiveEvent(view.getId(), name, data);
     }
 
 }

--- a/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -83,14 +83,15 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     private final ThemedReactContext context;
     private final EventDispatcher eventDispatcher;
 
-    public AirMapView(ThemedReactContext reactContext, Context appContext, AirMapManager manager,
+    public AirMapView(ThemedReactContext reactContext, AirMapManager manager,
             GoogleMapOptions googleMapOptions) {
-        super(appContext, googleMapOptions);
+        super(reactContext, googleMapOptions);
 
         this.manager = manager;
         this.context = reactContext;
 
         super.onCreate(null);
+        // TODO(lmr): what about onStart????
         super.onResume();
         super.getMapAsync(this);
 
@@ -141,7 +142,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
         this.map.setInfoWindowAdapter(this);
         this.map.setOnMarkerDragListener(this);
 
-        manager.pushEvent(this, "onMapReady", new WritableNativeMap());
+        manager.pushEvent(context, this, "onMapReady", new WritableNativeMap());
 
         final AirMapView view = this;
 
@@ -152,11 +153,11 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
 
                 event = makeClickEventData(marker.getPosition());
                 event.putString("action", "marker-press");
-                manager.pushEvent(view, "onMarkerPress", event);
+                manager.pushEvent(context, view, "onMarkerPress", event);
 
                 event = makeClickEventData(marker.getPosition());
                 event.putString("action", "marker-press");
-                manager.pushEvent(markerMap.get(marker), "onPress", event);
+                manager.pushEvent(context, markerMap.get(marker), "onPress", event);
 
                 // Return false to open the callout info window and center on the marker
                 // https://developers.google.com/android/reference/com/google/android/gms/maps/GoogleMap.OnMarkerClickListener
@@ -174,7 +175,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
             public void onPolygonClick(Polygon polygon) {
                 WritableMap event = makeClickEventData(polygon.getPoints().get(0));
                 event.putString("action", "polygon-press");
-                manager.pushEvent(polygonMap.get(polygon), "onPress", event);
+                manager.pushEvent(context, polygonMap.get(polygon), "onPress", event);
             }
         });
 
@@ -183,7 +184,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
             public void onPolylineClick(Polyline polyline) {
                 WritableMap event = makeClickEventData(polyline.getPoints().get(0));
                 event.putString("action", "polyline-press");
-                manager.pushEvent(polylineMap.get(polyline), "onPress", event);
+                manager.pushEvent(context, polylineMap.get(polyline), "onPress", event);
             }
         });
 
@@ -194,17 +195,17 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
 
                 event = makeClickEventData(marker.getPosition());
                 event.putString("action", "callout-press");
-                manager.pushEvent(view, "onCalloutPress", event);
+                manager.pushEvent(context, view, "onCalloutPress", event);
 
                 event = makeClickEventData(marker.getPosition());
                 event.putString("action", "callout-press");
                 AirMapMarker markerView = markerMap.get(marker);
-                manager.pushEvent(markerView, "onCalloutPress", event);
+                manager.pushEvent(context, markerView, "onCalloutPress", event);
 
                 event = makeClickEventData(marker.getPosition());
                 event.putString("action", "callout-press");
                 AirMapCallout infoWindow = markerView.getCalloutView();
-                if (infoWindow != null) manager.pushEvent(infoWindow, "onPress", event);
+                if (infoWindow != null) manager.pushEvent(context, infoWindow, "onPress", event);
             }
         });
 
@@ -213,7 +214,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
             public void onMapClick(LatLng point) {
                 WritableMap event = makeClickEventData(point);
                 event.putString("action", "press");
-                manager.pushEvent(view, "onPress", event);
+                manager.pushEvent(context, view, "onPress", event);
             }
         });
 
@@ -222,7 +223,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
             public void onMapLongClick(LatLng point) {
                 WritableMap event = makeClickEventData(point);
                 event.putString("action", "long-press");
-                manager.pushEvent(view, "onLongPress", makeClickEventData(point));
+                manager.pushEvent(context, view, "onLongPress", makeClickEventData(point));
             }
         });
 
@@ -655,31 +656,31 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     @Override
     public void onMarkerDragStart(Marker marker) {
         WritableMap event = makeClickEventData(marker.getPosition());
-        manager.pushEvent(this, "onMarkerDragStart", event);
+        manager.pushEvent(context, this, "onMarkerDragStart", event);
 
         AirMapMarker markerView = markerMap.get(marker);
         event = makeClickEventData(marker.getPosition());
-        manager.pushEvent(markerView, "onDragStart", event);
+        manager.pushEvent(context, markerView, "onDragStart", event);
     }
 
     @Override
     public void onMarkerDrag(Marker marker) {
         WritableMap event = makeClickEventData(marker.getPosition());
-        manager.pushEvent(this, "onMarkerDrag", event);
+        manager.pushEvent(context, this, "onMarkerDrag", event);
 
         AirMapMarker markerView = markerMap.get(marker);
         event = makeClickEventData(marker.getPosition());
-        manager.pushEvent(markerView, "onDrag", event);
+        manager.pushEvent(context, markerView, "onDrag", event);
     }
 
     @Override
     public void onMarkerDragEnd(Marker marker) {
         WritableMap event = makeClickEventData(marker.getPosition());
-        manager.pushEvent(this, "onMarkerDragEnd", event);
+        manager.pushEvent(context, this, "onMarkerDragEnd", event);
 
         AirMapMarker markerView = markerMap.get(marker);
         event = makeClickEventData(marker.getPosition());
-        manager.pushEvent(markerView, "onDragEnd", event);
+        manager.pushEvent(context, markerView, "onDragEnd", event);
     }
 
     private ProgressBar getMapLoadingProgressBar() {
@@ -772,6 +773,6 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
         Point point = new Point((int) ev.getX(), (int) ev.getY());
         LatLng coords = this.map.getProjection().fromScreenLocation(point);
         WritableMap event = makeClickEventData(coords);
-        manager.pushEvent(this, "onPanDrag", event);
+        manager.pushEvent(context, this, "onPanDrag", event);
     }
 }


### PR DESCRIPTION
to: @gpeal 

Before this change, we were using the application context to get the app's current activity, which was then passed into `MapView.<init>`, which was sometimes crashing by being null. There was no need to pass the activity into this, so instead we are just passing in the react context (which won't ever be null).

Also I am removing the private setting of the react context on the manager instance, which is a memory leak. Now `pushEvent` requires that you pass the react context along with it.

Tested on several devices and seems to be good.