### PR TITLE
Use provided as the gradle dependency

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -53,7 +53,7 @@ android {
 }
 
 dependencies {
-  compile "com.facebook.react:react-native:+"
+  provided "com.facebook.react:react-native:+"
   compile "com.google.android.gms:play-services-base:10.0.1"
   compile "com.google.android.gms:play-services-maps:10.0.1"
 }


### PR DESCRIPTION
to: @gpeal 
cc: @GantMan 

This allows the library to compile but will use whichever RN the
app is using and also allows it to pass POM verification on sonatype
which doesn't allow non-explicit dependencies.

I believe this can actually finally settle the gradle `:+` vs `:0.x` debate! This seems to work how we want it.