### PR TITLE
Update the android buildToolsVersion to 25.0.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,7 +40,7 @@ allprojects {
 
 android {
   compileSdkVersion 25
-  buildToolsVersion "23.0.3"
+  buildToolsVersion "25.0.0"
 
   defaultConfig {
     minSdkVersion 16

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -69,8 +69,8 @@ def enableSeparateBuildPerCPUArchitecture = false
 def enableProguardInReleaseBuilds = false
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.0"
 
     defaultConfig {
         applicationId "com.airbnb.android.react.maps.example"


### PR DESCRIPTION
When using the current android studio with the current SDKs you have the problem that your app is on version 25 and you can not create a APK without adjusting the buildToolsVersion in the build.gradle