### PR TITLE
Rename MapKit category to avoid conflicts with the one in RN

### DIFF
--- a/lib/ios/AirGoogleMaps/AIRGoogleMap.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMap.h
@@ -10,7 +10,7 @@
 #import <GoogleMaps/GoogleMaps.h>
 #import <MapKit/MapKit.h>
 #import "AIRGMSMarker.h"
-#import "RCTConvert+MapKit.h"
+#import "RCTConvert+AirMap.h"
 
 @interface AIRGoogleMap : GMSMapView
 

--- a/lib/ios/AirGoogleMaps/AIRGoogleMap.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMap.m
@@ -14,7 +14,7 @@
 #import <GoogleMaps/GoogleMaps.h>
 #import <MapKit/MapKit.h>
 #import <React/UIView+React.h>
-#import "RCTConvert+MapKit.h"
+#import "RCTConvert+AirMap.h"
 
 id regionAsJSON(MKCoordinateRegion region) {
   return @{

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
@@ -23,7 +23,7 @@
 #import "AIRMapCircle.h"
 #import "SMCalloutView.h"
 #import "AIRGoogleMapMarker.h"
-#import "RCTConvert+MapKit.h"
+#import "RCTConvert+AirMap.h"
 
 #import <MapKit/MapKit.h>
 

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapMarkerManager.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapMarkerManager.m
@@ -9,7 +9,7 @@
 #import "AIRGoogleMapMarker.h"
 #import <MapKit/MapKit.h>
 #import <React/RCTUIManager.h>
-#import "RCTConvert+MapKit.h"
+#import "RCTConvert+AirMap.h"
 
 @implementation AIRGoogleMapMarkerManager
 

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapPolygonManager.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapPolygonManager.m
@@ -11,7 +11,7 @@
 #import <React/RCTEventDispatcher.h>
 #import <React/RCTViewManager.h>
 #import <React/UIView+React.h>
-#import "RCTConvert+MapKit.h"
+#import "RCTConvert+AirMap.h"
 #import "AIRGoogleMapPolygon.h"
 
 @interface AIRGoogleMapPolygonManager()

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapPolylineManager.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapPolylineManager.m
@@ -12,7 +12,7 @@
 #import <React/RCTEventDispatcher.h>
 #import <React/RCTViewManager.h>
 #import <React/UIView+React.h>
-#import "RCTConvert+MapKit.h"
+#import "RCTConvert+AirMap.h"
 #import "AIRGoogleMapPolyline.h"
 
 @interface AIRGoogleMapPolylineManager()

--- a/lib/ios/AirMaps/AIRMap.h
+++ b/lib/ios/AirMaps/AIRMap.h
@@ -12,7 +12,7 @@
 
 #import <React/RCTComponent.h>
 #import "SMCalloutView.h"
-#import "RCTConvert+MapKit.h"
+#import "RCTConvert+AirMap.h"
 
 extern const CLLocationDegrees AIRMapDefaultSpan;
 extern const NSTimeInterval AIRMapRegionChangeObserveInterval;

--- a/lib/ios/AirMaps/AIRMapCircle.h
+++ b/lib/ios/AirMaps/AIRMapCircle.h
@@ -13,7 +13,7 @@
 
 #import "AIRMapCoordinate.h"
 #import "AIRMap.h"
-#import "RCTConvert+MapKit.h"
+#import "RCTConvert+AirMap.h"
 
 @interface AIRMapCircle: MKAnnotationView <MKOverlay>
 

--- a/lib/ios/AirMaps/AIRMapManager.m
+++ b/lib/ios/AirMaps/AIRMapManager.m
@@ -24,7 +24,7 @@
 #import "SMCalloutView.h"
 #import "AIRMapUrlTile.h"
 #import "AIRMapSnapshot.h"
-#import "RCTConvert+MapKit.h"
+#import "RCTConvert+AirMap.h"
 
 #import <MapKit/MapKit.h>
 

--- a/lib/ios/AirMaps/AIRMapMarker.h
+++ b/lib/ios/AirMaps/AIRMapMarker.h
@@ -16,7 +16,7 @@
 #import <React/RCTComponent.h>
 #import "AIRMap.h"
 #import "SMCalloutView.h"
-#import "RCTConvert+MapKit.h"
+#import "RCTConvert+AirMap.h"
 
 @class RCTBridge;
 

--- a/lib/ios/AirMaps/AIRMapPolygon.h
+++ b/lib/ios/AirMaps/AIRMapPolygon.h
@@ -12,7 +12,7 @@
 #import <React/RCTView.h>
 #import "AIRMapCoordinate.h"
 #import "AIRMap.h"
-#import "RCTConvert+MapKit.h"
+#import "RCTConvert+AirMap.h"
 
 
 

--- a/lib/ios/AirMaps/AIRMapPolygonManager.m
+++ b/lib/ios/AirMaps/AIRMapPolygonManager.m
@@ -15,7 +15,7 @@
 #import <React/RCTEventDispatcher.h>
 #import <React/RCTViewManager.h>
 #import <React/UIView+React.h>
-#import "RCTConvert+MapKit.h"
+#import "RCTConvert+AirMap.h"
 #import "AIRMapMarker.h"
 #import "AIRMapPolygon.h"
 

--- a/lib/ios/AirMaps/AIRMapPolyline.h
+++ b/lib/ios/AirMaps/AIRMapPolyline.h
@@ -12,7 +12,7 @@
 #import <React/RCTView.h>
 #import "AIRMapCoordinate.h"
 #import "AIRMap.h"
-#import "RCTConvert+MapKit.h"
+#import "RCTConvert+AirMap.h"
 
 
 @interface AIRMapPolyline: MKAnnotationView <MKOverlay>

--- a/lib/ios/AirMaps/AIRMapPolylineManager.m
+++ b/lib/ios/AirMaps/AIRMapPolylineManager.m
@@ -15,7 +15,7 @@
 #import <React/RCTEventDispatcher.h>
 #import <React/RCTViewManager.h>
 #import <React/UIView+React.h>
-#import "RCTConvert+MapKit.h"
+#import "RCTConvert+AirMap.h"
 #import "AIRMapMarker.h"
 #import "AIRMapPolyline.h"
 

--- a/lib/ios/AirMaps/AIRMapUrlTile.h
+++ b/lib/ios/AirMaps/AIRMapUrlTile.h
@@ -14,7 +14,7 @@
 #import <React/RCTView.h>
 #import "AIRMapCoordinate.h"
 #import "AIRMap.h"
-#import "RCTConvert+MapKit.h"
+#import "RCTConvert+AirMap.h"
 
 @interface AIRMapUrlTile : MKAnnotationView <MKOverlay>
 

--- a/lib/ios/AirMaps/RCTConvert+AirMap.h
+++ b/lib/ios/AirMaps/RCTConvert+AirMap.h
@@ -7,7 +7,7 @@
 #import <MapKit/MapKit.h>
 #import <React/RCTConvert.h>
 
-@interface RCTConvert (MapKit)
+@interface RCTConvert (AirMap)
 
 + (MKCoordinateSpan)MKCoordinateSpan:(id)json;
 + (MKCoordinateRegion)MKCoordinateRegion:(id)json;

--- a/lib/ios/AirMaps/RCTConvert+AirMap.m
+++ b/lib/ios/AirMaps/RCTConvert+AirMap.m
@@ -3,12 +3,12 @@
 // Copyright (c) 2015 Facebook. All rights reserved.
 //
 
-#import "RCTConvert+MapKit.h"
+#import "RCTConvert+AirMap.h"
 
 #import <React/RCTConvert+CoreLocation.h>
 #import "AIRMapCoordinate.h"
 
-@implementation RCTConvert (MapKit)
+@implementation RCTConvert (AirMap)
 
 + (MKCoordinateSpan)MKCoordinateSpan:(id)json
 {


### PR DESCRIPTION
This should fix #1168, I haven't reproduced the problem but my guess is that is uses the category in RN instead of the one in AirMaps.

cc @lelandrichardson 