### PR TITLE
Add babelrc to npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 example
+.babelrc


### PR DESCRIPTION
I get errors saying that the plugin "module-resolver" does not exist because the .babelrc is published with the react-native-maps package. This PR will ensure this is not published in the future and as to avoid this error.