### PR TITLE
Update from View.propTypes to ViewPropTypes to match RN v0.44.0

### DIFF
--- a/lib/components/MapCallout.js
+++ b/lib/components/MapCallout.js
@@ -2,6 +2,7 @@ import React, { PropTypes } from 'react';
 import {
   View,
   StyleSheet,
+  ViewPropTypes,
 } from 'react-native';
 import decorateMapComponent, {
   SUPPORTED,
@@ -9,7 +10,7 @@ import decorateMapComponent, {
 } from './decorateMapComponent';
 
 const propTypes = {
-  ...View.propTypes,
+  ...ViewPropTypes,
   tooltip: PropTypes.bool,
   onPress: PropTypes.func,
 };

--- a/lib/components/MapCallout.js
+++ b/lib/components/MapCallout.js
@@ -1,6 +1,5 @@
 import React, { PropTypes } from 'react';
 import {
-  View,
   StyleSheet,
   ViewPropTypes,
 } from 'react-native';

--- a/lib/components/MapCircle.js
+++ b/lib/components/MapCircle.js
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react';
 import {
   View,
+  ViewPropTypes,
 } from 'react-native';
 import decorateMapComponent, {
   USES_DEFAULT_IMPLEMENTATION,
@@ -8,7 +9,7 @@ import decorateMapComponent, {
 } from './decorateMapComponent';
 
 const propTypes = {
-  ...View.propTypes,
+  ...ViewPropTypes,
 
   /**
    * The coordinate of the center of the circle

--- a/lib/components/MapCircle.js
+++ b/lib/components/MapCircle.js
@@ -1,6 +1,5 @@
 import React, { PropTypes } from 'react';
 import {
-  View,
   ViewPropTypes,
 } from 'react-native';
 import decorateMapComponent, {

--- a/lib/components/MapMarker.js
+++ b/lib/components/MapMarker.js
@@ -6,6 +6,7 @@ import {
   NativeModules,
   Animated,
   findNodeHandle,
+  ViewPropTypes,
 } from 'react-native';
 
 import resolveAssetSource from 'react-native/Libraries/Image/resolveAssetSource';
@@ -22,7 +23,7 @@ const viewConfig = {
 };
 
 const propTypes = {
-  ...View.propTypes,
+  ...ViewPropTypes,
 
   // TODO(lmr): get rid of these?
   identifier: PropTypes.string,

--- a/lib/components/MapMarker.js
+++ b/lib/components/MapMarker.js
@@ -1,6 +1,5 @@
 import React, { PropTypes } from 'react';
 import {
-  View,
   StyleSheet,
   Platform,
   NativeModules,

--- a/lib/components/MapPolygon.js
+++ b/lib/components/MapPolygon.js
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react';
 import {
   View,
+  ViewPropTypes,
 } from 'react-native';
 import decorateMapComponent, {
   USES_DEFAULT_IMPLEMENTATION,
@@ -8,7 +9,7 @@ import decorateMapComponent, {
 } from './decorateMapComponent';
 
 const propTypes = {
-  ...View.propTypes,
+  ...ViewPropTypes,
 
   /**
    * An array of coordinates to describe the polygon

--- a/lib/components/MapPolygon.js
+++ b/lib/components/MapPolygon.js
@@ -1,6 +1,5 @@
 import React, { PropTypes } from 'react';
 import {
-  View,
   ViewPropTypes,
 } from 'react-native';
 import decorateMapComponent, {

--- a/lib/components/MapPolyline.js
+++ b/lib/components/MapPolyline.js
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react';
 import {
   View,
+  ViewPropTypes,
 } from 'react-native';
 import decorateMapComponent, {
   USES_DEFAULT_IMPLEMENTATION,
@@ -8,7 +9,7 @@ import decorateMapComponent, {
 } from './decorateMapComponent';
 
 const propTypes = {
-  ...View.propTypes,
+  ...ViewPropTypes,
 
   /**
    * An array of coordinates to describe the polygon

--- a/lib/components/MapPolyline.js
+++ b/lib/components/MapPolyline.js
@@ -1,6 +1,5 @@
 import React, { PropTypes } from 'react';
 import {
-  View,
   ViewPropTypes,
 } from 'react-native';
 import decorateMapComponent, {

--- a/lib/components/MapUrlTile.js
+++ b/lib/components/MapUrlTile.js
@@ -1,7 +1,6 @@
 import React, { PropTypes } from 'react';
 
 import {
-  View,
   ViewPropTypes,
 } from 'react-native';
 

--- a/lib/components/MapUrlTile.js
+++ b/lib/components/MapUrlTile.js
@@ -2,6 +2,7 @@ import React, { PropTypes } from 'react';
 
 import {
   View,
+  ViewPropTypes,
 } from 'react-native';
 
 import decorateMapComponent, {
@@ -10,7 +11,7 @@ import decorateMapComponent, {
 } from './decorateMapComponent';
 
 const propTypes = {
-  ...View.propTypes,
+  ...ViewPropTypes,
 
   /**
    * The url template of the tile server. The patterns {x} {y} {z} will be replaced at runtime

--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -2,7 +2,6 @@ import React, { PropTypes } from 'react';
 import {
   EdgeInsetsPropType,
   Platform,
-  View,
   Animated,
   requireNativeComponent,
   NativeModules,

--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -8,6 +8,7 @@ import {
   NativeModules,
   ColorPropType,
   findNodeHandle,
+  ViewPropTypes,
 } from 'react-native';
 import MapMarker from './MapMarker';
 import MapPolyline from './MapPolyline';
@@ -45,7 +46,7 @@ const viewConfig = {
 };
 
 const propTypes = {
-  ...View.propTypes,
+  ...ViewPropTypes,
   /**
    * When provider is "google", we will use GoogleMaps.
    * Any value other than "google" will default to using
@@ -59,7 +60,7 @@ const propTypes = {
    * Used to style and layout the `MapView`.  See `StyleSheet.js` and
    * `ViewStylePropTypes.js` for more info.
    */
-  style: View.propTypes.style,
+  style: ViewPropTypes.style,
 
   /**
    * A json object that describes the style of the map. This is transformed to a string


### PR DESCRIPTION
Update the ViewPropTypes to match the last revision of React Native V0.44.0

> View.propTypes to ViewPropTypes (53905a5) - @bvaughn

https://github.com/facebook/react-native/releases