### PR TITLE
Add Marker rotation for Google Maps on iOS

### DIFF
--- a/docs/marker.md
+++ b/docs/marker.md
@@ -15,7 +15,7 @@
 | `calloutAnchor` | `Point` |  | Specifies the point in the marker image at which to anchor the callout when it is displayed. This is specified in the same coordinate system as the anchor. See the `anchor` prop for more details.<br/><br/> The default is the top middle of the image.<br/><br/> For ios, see the `calloutOffset` prop.
 | `flat` | `Boolean` |  | Sets whether this marker should be flat against the map true or a billboard facing the camera false.
 | `identifier` | `String` |  | An identifier used to reference this marker at a later date.
-| `rotation` | `Float` |  | A float number indicating marker's rotation angle.
+| `rotation` | `Float` |  | A float number indicating marker's rotation angle, in degrees.
 | `draggable` | `<null>` |  | This is a non-value based prop. Adding this allows the marker to be draggable (re-positioned).
 
 ## Events

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapMarker.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapMarker.h
@@ -17,6 +17,7 @@
 @property (nonatomic, strong) AIRGoogleMapCallout *calloutView;
 @property (nonatomic, strong) NSString *identifier;
 @property (nonatomic, assign) CLLocationCoordinate2D coordinate;
+@property (nonatomic, assign) CLLocationDegrees rotation;
 @property (nonatomic, strong) AIRGMSMarker* realMarker;
 @property (nonatomic, copy) RCTBubblingEventBlock onPress;
 @property (nonatomic, copy) RCTDirectEventBlock onDragStart;

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapMarker.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapMarker.m
@@ -157,6 +157,14 @@ CGRect unionRect(CGRect a, CGRect b) {
   return _realMarker.position;
 }
 
+- (void)setRotation:(CLLocationDegrees)rotation {
+    _realMarker.rotation = rotation;
+}
+
+- (CLLocationDegrees)rotation {
+    return _realMarker.rotation;
+}
+
 - (void)setIdentifier:(NSString *)identifier {
   _realMarker.identifier = identifier;
 }

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapMarkerManager.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapMarkerManager.m
@@ -28,6 +28,7 @@ RCT_EXPORT_MODULE()
 
 RCT_EXPORT_VIEW_PROPERTY(identifier, NSString)
 RCT_EXPORT_VIEW_PROPERTY(coordinate, CLLocationCoordinate2D)
+RCT_EXPORT_VIEW_PROPERTY(rotation, CLLocationDegrees)
 RCT_EXPORT_VIEW_PROPERTY(onPress, RCTBubblingEventBlock)
 RCT_REMAP_VIEW_PROPERTY(image, imageSrc, NSString)
 RCT_EXPORT_VIEW_PROPERTY(title, NSString)


### PR DESCRIPTION
I added the rotation for the Google Maps provider on iOS. It was already working on Android.
I can't figure out how to do it with `MKAnnotationView` for the MapKit provider..

The rotation is in degrees, starting from 0 to 360.