### PR TITLE
[iOS] Allow adding of custom MKTileOverlays

### DIFF
--- a/lib/ios/AirMaps/AIRMapManager.m
+++ b/lib/ios/AirMaps/AIRMapManager.m
@@ -478,6 +478,8 @@ RCT_EXPORT_METHOD(takeSnapshot:(nonnull NSNumber *)reactTag
         return ((AIRMapCircle *)overlay).renderer;
     } else if ([overlay isKindOfClass:[AIRMapUrlTile class]]) {
         return ((AIRMapUrlTile *)overlay).renderer;
+    } else if([overlay isKindOfClass:[MKTileOverlay class]]) {
+        return [[MKTileOverlayRenderer alloc] initWithTileOverlay:overlay];
     } else {
         return nil;
     }


### PR DESCRIPTION
This PR adds a MKTileOverlayRenderer for generic tile overlays in the mapView's `rendererForOverlay` delegate method.

Our application has a need to add tile overlays to the react native map from native code. This is already possible on Android, but iOS needs the correct renderer in the map delegate.

I am not sure if other developers have this use case, but I thought I'd propose this as an improvement. It won't affect any other behavior. 