### PR TITLE
Fixes google map null pointer exception

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -314,7 +314,9 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
             map.setMyLocationEnabled(false);
           }
             synchronized (AirMapView.this) {
-                AirMapView.this.onPause();
+                if(!destroyed) {
+                    AirMapView.this.onPause();
+                }
                 paused = true;
             }
         }


### PR DESCRIPTION
Sometimes AirMapView doDestroy is called before LifecycleEventListener onHostPause. This fixes https://github.com/airbnb/react-native-maps/issues/1358