### PR TITLE
Add ability to load marker image from drawable

### DIFF
--- a/lib/components/MapMarker.js
+++ b/lib/components/MapMarker.js
@@ -256,7 +256,7 @@ class MapMarker extends React.Component {
     let image;
     if (this.props.image) {
       image = resolveAssetSource(this.props.image) || {};
-      image = image.uri;
+      image = image.uri || this.props.image;
     }
 
     const AIRMapMarker = this.getAirComponent();


### PR DESCRIPTION
Add ability to load marker images from drawable.

There are some methods to load drawables as markers in the AirMapMarker class but it seems that it was impossible to use those. Here, we just have to pass the drawable name to the image prop, and it will load our drawable.

It can fix some memory issues when you want to use a custom view for a big amount of markers using local images.