### PR TITLE
[Android Crash] skip region monitoring if map object is null

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -699,13 +699,13 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
   // Timer Implementation
 
   public void startMonitoringRegion() {
-    if (isMonitoringRegion) return;
+    if (map == null || isMonitoringRegion) return;
     timerHandler.postDelayed(timerRunnable, 100);
     isMonitoringRegion = true;
   }
 
   public void stopMonitoringRegion() {
-    if (!isMonitoringRegion) return;
+    if (map == null || !isMonitoringRegion) return;
     timerHandler.removeCallbacks(timerRunnable);
     isMonitoringRegion = false;
   }


### PR DESCRIPTION
This happens if google play services version is lower than required. It is to fix issues#618

There are also other places checking if `map == null` before calling `startMonitoringRegion` or `stopMonitoringRegion` usually followed with another call, e.g.
```java
public void animateToRegion(LatLngBounds bounds, int duration) {
    if (map != null) {
      startMonitoringRegion();
      map.animateCamera(CameraUpdateFactory.newLatLngBounds(bounds, 0), duration, null);
    }
  }
```

However, both ways of check map's nullability are lack of elegance.   