### PR TITLE
updates npm cache clean command

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -203,7 +203,7 @@ Enter the name of the API key and create it.
 1. Clean the cache :
   ```
    watchman watch-del-all
-   npm clean cache
+   npm cache clean
   ```
 
 1. When starting emulator, make sure you have enabled `Wipe user data`.


### PR DESCRIPTION
latest version of npm seems to be missing the command ```npm clean cache``` but ```npm cache clean``` seems to work. Might help copy-pasters like me.