### PR TITLE
Add Google Maps legalNotice constant

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapModule.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapModule.java
@@ -15,12 +15,16 @@ import com.facebook.react.uimanager.NativeViewHierarchyManager;
 import com.facebook.react.uimanager.UIBlock;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.common.GoogleApiAvailability;
 
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+
+import java.util.Map;
+import java.util.HashMap;
 
 import javax.annotation.Nullable;
 
@@ -38,6 +42,13 @@ public class AirMapModule extends ReactContextBaseJavaModule {
   @Override
   public String getName() {
     return "AirMapModule";
+  }
+
+  @Override
+  public Map<String, Object> getConstants() {
+    final Map<String, Object> constants = new HashMap<>();
+    constants.put("legalNotice", GoogleApiAvailability.getInstance().getOpenSourceSoftwareLicenseInfo(getReactApplicationContext()));
+    return constants;
   }
 
   public Activity getActivity() {

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
@@ -222,6 +222,9 @@ RCT_EXPORT_METHOD(takeSnapshot:(nonnull NSNumber *)reactTag
   }];
 }
 
+- (NSDictionary *)constantsToExport {
+  return @{ @"legalNotice": [GMSServices openSourceLicenseInfo] };
+}
 
 - (void)mapViewDidFinishTileRendering:(GMSMapView *)mapView {
     AIRGoogleMap *googleMapView = (AIRGoogleMap *)mapView;


### PR DESCRIPTION
According to the Google Map iOS SDK [attribution requirements](https://developers.google.com/maps/documentation/ios-sdk/intro#attribution_requirements) you need to include their legal notice in your app. This PR exposes this text as a constant. There might be a nicer way to use this but it can be used like this:

```js
const noticeText = Platform.select({
    ios: () => NativeModules.AIRGoogleMapManager.legalNotice,
    android: () => NativeModules.AirMapModule.legalNotice,
})();
```