### PR TITLE
Fix android edgePadding

### DIFF
--- a/docs/mapview.md
+++ b/docs/mapview.md
@@ -67,6 +67,7 @@ To access event data, you will need to use `e.nativeEvent`. For example, `onPres
 | `fitToElements` | `animated: Boolean` |
 | `fitToSuppliedMarkers` | `markerIDs: String[]`, `animated: Boolean` | If you need to use this in `ComponentDidMount`, make sure you put it in a timeout or it will cause performance problems.
 | `fitToCoordinates` | `coordinates: Array<LatLng>, options: { edgePadding: EdgePadding, animated: Boolean }` | If called in `ComponentDidMount` in android, it will cause an exception. It is recommended to call it from the MapView `onLayout` event.
+| `setPadding` | `edgePadding: EdgePadding` | **Note**: Android only.
 
 
 

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
@@ -32,6 +32,7 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
   private static final int FIT_TO_ELEMENTS = 3;
   private static final int FIT_TO_SUPPLIED_MARKERS = 4;
   private static final int FIT_TO_COORDINATES = 5;
+  private static final int SET_PADDING = 6;
 
   private final Map<String, Integer> MAP_TYPES = MapBuilder.of(
       "standard", GoogleMap.MAP_TYPE_NORMAL,
@@ -235,6 +236,9 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
       case FIT_TO_COORDINATES:
         view.fitToCoordinates(args.getArray(0), args.getMap(1), args.getBoolean(2));
         break;
+      case SET_PADDING:
+        view.setPadding(args.getMap(0));
+        break;
     }
   }
 
@@ -269,7 +273,8 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
         "animateToCoordinate", ANIMATE_TO_COORDINATE,
         "fitToElements", FIT_TO_ELEMENTS,
         "fitToSuppliedMarkers", FIT_TO_SUPPLIED_MARKERS,
-        "fitToCoordinates", FIT_TO_COORDINATES
+        "fitToCoordinates", FIT_TO_COORDINATES,
+        "setPadding", SET_PADDING
     );
   }
 

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -652,8 +652,9 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     CameraUpdate cu = CameraUpdateFactory.newLatLngBounds(bounds, baseMapPadding);
 
     if (edgePadding != null) {
-      map.setPadding(edgePadding.getInt("left"), edgePadding.getInt("top"),
-          edgePadding.getInt("right"), edgePadding.getInt("bottom"));
+      int density = (int) getContext().getResources().getDisplayMetrics().density;
+      map.setPadding(edgePadding.getInt("left") * density, edgePadding.getInt("top") * density,
+          edgePadding.getInt("right") * density, edgePadding.getInt("bottom") * density);
     }
 
     if (animated) {
@@ -662,8 +663,6 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     } else {
       map.moveCamera(cu);
     }
-    map.setPadding(0, 0, 0,
-        0); // Without this, the Google logo is moved up by the value of edgePadding.bottom
   }
 
   // InfoWindowAdapter interface

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -665,6 +665,12 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     }
   }
 
+  public void setPadding(ReadableMap edgePadding) {
+    int density = (int) getContext().getResources().getDisplayMetrics().density;
+    map.setPadding(edgePadding.getInt("left") * density, edgePadding.getInt("top") * density,
+        edgePadding.getInt("right") * density, edgePadding.getInt("bottom") * density);
+  }
+
   // InfoWindowAdapter interface
 
   @Override

--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -516,6 +516,12 @@ class MapView extends React.Component {
     this._runCommand('fitToCoordinates', [coordinates, edgePadding, animated]);
   }
 
+  setPadding(edgePadding) {
+    if (Platform.OS === 'android') {
+      this._runCommand('setPadding', [{top: 0, right: 0, bottom: 0, left: 0, ...edgePadding}]);
+    }
+  }
+
   /**
    * Takes a snapshot of the map and saves it to a picture
    * file or returns the image as a base64 encoded string.


### PR DESCRIPTION
We found that the edgePadding value while using map.fitToCoordinates was not being taken into account on Android.

Sample:

```js
this.map.fitToCoordinates(coordinates, {
      animated: animate,
      edgePadding: {
        top: Math.ceil(props.markerPadding.top + this.mapLayout.height * props.viewport.top),
        right: Math.ceil(props.markerPadding.right + this.mapLayout.width * props.viewport.right),
        bottom: Math.ceil(props.markerPadding.bottom + this.mapLayout.height * props.viewport.bottom),
        left: Math.ceil(props.markerPadding.left + this.mapLayout.width * props.viewport.left),
      },
    });
```

On iOS this was working as expected, but on Android the edgePadding values made no difference.

Looking at the source, the user's edgePadding value was immediately overwritten with 0,0,0,0.  
The intention of this seems to be to prevent the Google Logo from moving upwards based on the bottom padding, however (a) this made edgePadding pointless and (b) the Google Logo moving when padding is set is an intentional part of the Google Maps API (see https://developers.google.com/maps/documentation/android-api/map#map_padding)

Additionally the screen's density was not taken into account (thanks to #239 for inspiration on the second point). 

iOS and Android edgePadding now works the same.

Related to issue #1356,  and PR #239

