### PR TITLE
Fix the crashing of the application when Goole Play Services need to be updated

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -718,18 +718,20 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     @Override
     public void run() {
 
-      Projection projection = map.getProjection();
-      VisibleRegion region = (projection != null) ? projection.getVisibleRegion() : null;
-      LatLngBounds bounds = (region != null) ? region.latLngBounds : null;
+      if (map != null) {
+        Projection projection = map.getProjection();
+        VisibleRegion region = (projection != null) ? projection.getVisibleRegion() : null;
+        LatLngBounds bounds = (region != null) ? region.latLngBounds : null;
 
-      if ((bounds != null) &&
-          (lastBoundsEmitted == null ||
-              LatLngBoundsUtils.BoundsAreDifferent(bounds, lastBoundsEmitted))) {
-        LatLng center = map.getCameraPosition().target;
-        lastBoundsEmitted = bounds;
-        eventDispatcher.dispatchEvent(new RegionChangeEvent(getId(), bounds, center, true));
+        if ((bounds != null) &&
+            (lastBoundsEmitted == null ||
+                LatLngBoundsUtils.BoundsAreDifferent(bounds, lastBoundsEmitted))) {
+          LatLng center = map.getCameraPosition().target;
+          lastBoundsEmitted = bounds;
+          eventDispatcher.dispatchEvent(new RegionChangeEvent(getId(), bounds, center, true));
+        }
       }
-
+      
       timerHandler.postDelayed(this, 100);
     }
   };


### PR DESCRIPTION
Fix the crashing of the application when a user presses on the map and the Google Play Services need to be updated or at the moment of the process of updating.

```
E/AndroidRuntime( 5908): java.lang.NullPointerException: Attempt to invoke virtual method 'com.google.android.gms.maps.Projection com.google.android.gms.maps.GoogleMap.getProjection()' on a null object reference
E/AndroidRuntime( 5908): 	at com.airbnb.android.react.maps.AirMapView$13.run(AirMapView.java:643)
E/AndroidRuntime( 5908): 	at android.os.Handler.handleCallback(Handler.java:739)
E/AndroidRuntime( 5908): 	at android.os.Handler.dispatchMessage(Handler.java:95)
E/AndroidRuntime( 5908): 	at android.os.Looper.loop(Looper.java:135)
E/AndroidRuntime( 5908): 	at android.app.ActivityThread.main(ActivityThread.java:5264)
E/AndroidRuntime( 5908): 	at java.lang.reflect.Method.invoke(Native Method)
E/AndroidRuntime( 5908): 	at java.lang.reflect.Method.invoke(Method.java:372)
E/AndroidRuntime( 5908): 	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:900)
E/AndroidRuntime( 5908): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:695)
```