### PR TITLE
Fall back to View.propTypes if ViewPropTypes is not available (#1473)

### DIFF
--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -8,6 +8,7 @@ import {
   NativeModules,
   ColorPropType,
   findNodeHandle,
+  View,
   ViewPropTypes,
 } from 'react-native';
 import MapMarker from './MapMarker';
@@ -45,8 +46,11 @@ const viewConfig = {
   },
 };
 
+// if ViewPropTypes is not defined fall back to View.propType (to support RN < 0.44)
+const viewPropTypes = ViewPropTypes || View.propTypes;
+
 const propTypes = {
-  ...ViewPropTypes,
+  ...viewPropTypes,
   /**
    * When provider is "google", we will use GoogleMaps.
    * Any value other than "google" will default to using
@@ -60,7 +64,7 @@ const propTypes = {
    * Used to style and layout the `MapView`.  See `StyleSheet.js` and
    * `ViewStylePropTypes.js` for more info.
    */
-  style: ViewPropTypes.style,
+  style: viewPropTypes.style,
 
   /**
    * A json object that describes the style of the map. This is transformed to a string


### PR DESCRIPTION
This is to provide support for RN <0.44 where ViewPropTypes was introduced