### PR TITLE
Fix timing function used in AnimatedRegion.spring

### DIFF
--- a/lib/components/AnimatedRegion.js
+++ b/lib/components/AnimatedRegion.js
@@ -111,25 +111,25 @@ export default class AnimatedMapRegion extends AnimatedWithChildren {
   spring(config) {
     var animations = [];
     config.hasOwnProperty('latitude') &&
-    animations.push(Animated.timing(this.latitude, {
+    animations.push(Animated.spring(this.latitude, {
       ...config,
       toValue: config.latitude
     }));
 
     config.hasOwnProperty('longitude') &&
-    animations.push(Animated.timing(this.longitude, {
+    animations.push(Animated.spring(this.longitude, {
       ...config,
       toValue: config.longitude
     }));
 
     config.hasOwnProperty('latitudeDelta') &&
-    animations.push(Animated.timing(this.latitudeDelta, {
+    animations.push(Animated.spring(this.latitudeDelta, {
       ...config,
       toValue: config.latitudeDelta
     }));
 
     config.hasOwnProperty('longitudeDelta') &&
-    animations.push(Animated.timing(this.longitudeDelta, {
+    animations.push(Animated.spring(this.longitudeDelta, {
       ...config,
       toValue: config.longitudeDelta
     }));


### PR DESCRIPTION
It seems the animation function, `timing`, used in the `AnimatedRegion.spring` method should actually be `spring` to reflect the name of the function.

If this is intended, I'd suggest merely calling `AnimatedRegion.timing` from `AnimatedRegion.spring` instead of re-implementing it. I think this also would have the benefit of being more transparent for future readers of the code.