### PR TITLE
Remove caret from "react": "^16.0.0-alpha.12"

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "gitbook-cli": "^2.3.0",
     "lodash": "^4.17.2",
     "prop-types": "^15.5.10",
-    "react": "^16.0.0-alpha.12",
+    "react": "16.0.0-alpha.12",
     "react-native": "^0.45.1"
   },
   "rnpm": {


### PR DESCRIPTION
`npm install` / `yarn install` auto updates to `16.0.0-alpha.13` which
breaks the proptypes import.

This affects the `example` app:

![proptypes_error_30](https://user-images.githubusercontent.com/6293471/28498452-a2f3d864-6fa6-11e7-812c-872fe3046b85.png)


Removing caret to prevent auto update to `alpha.13`.

For more information: https://github.com/facebook/react-native/issues/14454