### PR TITLE
fix rare android crashes when map size is 0

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -541,16 +541,17 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     // a proper camera move
     if (boundsToMove != null) {
       HashMap<String, Float> data = (HashMap<String, Float>) extraData;
-      float width = data.get("width");
-      float height = data.get("height");
-      map.moveCamera(
-          CameraUpdateFactory.newLatLngBounds(
-              boundsToMove,
-              (int) width,
-              (int) height,
-              0
-          )
-      );
+      int width = data.get("width") == null ? 0 : data.get("width").intValue();
+      int height = data.get("height") == null ? 0 : data.get("height").intValue();
+
+      //fix for https://github.com/airbnb/react-native-maps/issues/245,
+      //it's not guaranteed the passed-in height and width would be greater than 0.
+      if (width <= 0 || height <= 0) {
+        map.moveCamera(CameraUpdateFactory.newLatLngBounds(boundsToMove, 0));
+      } else {
+        map.moveCamera(CameraUpdateFactory.newLatLngBounds(boundsToMove, width, height, 0));
+      }
+
       boundsToMove = null;
     }
   }


### PR DESCRIPTION
This is to fix https://github.com/airbnb/react-native-maps/issues/245

This cannot be easily reproduced, and only happens in our released app from time to time (not often). 

The safest way is to check width and height before calling `newLatLngBounds(boundsToMove, width, height, 0)` 