### PR TITLE
Adds support to animateToBearing and animateToViewingAngle ( IOS + Android )

### DIFF
--- a/docs/mapview.md
+++ b/docs/mapview.md
@@ -64,6 +64,8 @@ To access event data, you will need to use `e.nativeEvent`. For example, `onPres
 |---|---|---|
 | `animateToRegion` | `region: Region`, `duration: Number` |
 | `animateToCoordinate` | `coordinate: LatLng`, `duration: Number` |
+| `animateToBearing` | `bearing: Number`, `duration: Number` |
+| `animateToViewingAngle` | `angle: Number`, `duration: Number` |
 | `fitToElements` | `animated: Boolean` |
 | `fitToSuppliedMarkers` | `markerIDs: String[]`, `animated: Boolean` | If you need to use this in `ComponentDidMount`, make sure you put it in a timeout or it will cause performance problems.
 | `fitToCoordinates` | `coordinates: Array<LatLng>, options: { edgePadding: EdgePadding, animated: Boolean }` | If called in `ComponentDidMount` in android, it will cause an exception. It is recommended to call it from the MapView `onLayout` event.

--- a/example/examples/DisplayLatLng.js
+++ b/example/examples/DisplayLatLng.js
@@ -47,6 +47,18 @@ class DisplayLatLng extends React.Component {
     this.map.animateToCoordinate(this.randomCoordinate());
   }
 
+  animateToRandomBearing() {
+    this.map.animateToBearing(this.getRandomFloat(-360, 360));
+  }
+
+  animateToRandomViewingAngle() {
+    this.map.animateToViewingAngle(this.getRandomFloat(0, 90));
+  }
+
+  getRandomFloat(min, max) {
+    return (Math.random() * (max - min)) + min;
+  }
+
   randomCoordinate() {
     const region = this.state.region;
     return {
@@ -97,6 +109,18 @@ class DisplayLatLng extends React.Component {
             style={[styles.bubble, styles.button]}
           >
             <Text style={styles.buttonText}>Animate (Coordinate)</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            onPress={() => this.animateToRandomBearing()}
+            style={[styles.bubble, styles.button]}
+          >
+            <Text style={styles.buttonText}>Animate (Bearing)</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            onPress={() => this.animateToRandomViewingAngle()}
+            style={[styles.bubble, styles.button]}
+          >
+            <Text style={styles.buttonText}>Animate (View Angle)</Text>
           </TouchableOpacity>
         </View>
       </View>

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
@@ -29,9 +29,11 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
   private static final String REACT_CLASS = "AIRMap";
   private static final int ANIMATE_TO_REGION = 1;
   private static final int ANIMATE_TO_COORDINATE = 2;
-  private static final int FIT_TO_ELEMENTS = 3;
-  private static final int FIT_TO_SUPPLIED_MARKERS = 4;
-  private static final int FIT_TO_COORDINATES = 5;
+  private static final int ANIMATE_TO_VIEWING_ANGLE = 3;
+  private static final int ANIMATE_TO_BEARING = 4;
+  private static final int FIT_TO_ELEMENTS = 5;
+  private static final int FIT_TO_SUPPLIED_MARKERS = 6;
+  private static final int FIT_TO_COORDINATES = 7;
 
   private final Map<String, Integer> MAP_TYPES = MapBuilder.of(
       "standard", GoogleMap.MAP_TYPE_NORMAL,
@@ -195,6 +197,8 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
     Double lng;
     Double lngDelta;
     Double latDelta;
+    float bearing;
+    float angle;
     ReadableMap region;
 
     switch (commandId) {
@@ -220,6 +224,18 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
         view.animateToCoordinate(new LatLng(lat, lng), duration);
         break;
 
+      case ANIMATE_TO_VIEWING_ANGLE:
+        angle = (float)args.getDouble(0);
+        duration = args.getInt(1);
+        view.animateToViewingAngle(angle, duration);
+        break;
+      
+      case ANIMATE_TO_BEARING:
+        bearing = (float)args.getDouble(0);
+        duration = args.getInt(1);
+        view.animateToBearing(bearing, duration);
+        break;
+      
       case FIT_TO_ELEMENTS:
         view.fitToElements(args.getBoolean(0));
         break;
@@ -262,6 +278,8 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
     return MapBuilder.of(
         "animateToRegion", ANIMATE_TO_REGION,
         "animateToCoordinate", ANIMATE_TO_COORDINATE,
+        "animateToViewingAngle", ANIMATE_TO_VIEWING_ANGLE,
+        "animateToBearing", ANIMATE_TO_BEARING,
         "fitToElements", FIT_TO_ELEMENTS,
         "fitToSuppliedMarkers", FIT_TO_SUPPLIED_MARKERS,
         "fitToCoordinates", FIT_TO_COORDINATES

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -562,6 +562,26 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     }
   }
 
+  public void animateToViewingAngle(float angle, int duration) {
+    if (map != null) {
+      startMonitoringRegion();
+      CameraPosition cameraPosition = new CameraPosition.Builder(map.getCameraPosition())
+          .tilt(angle)
+          .build();
+      map.animateCamera(CameraUpdateFactory.newCameraPosition(cameraPosition), duration, null);
+    }
+  }
+
+  public void animateToBearing(float bearing, int duration) {
+    if (map != null) {
+      startMonitoringRegion();
+      CameraPosition cameraPosition = new CameraPosition.Builder(map.getCameraPosition())
+          .bearing(bearing)
+          .build();
+      map.animateCamera(CameraUpdateFactory.newCameraPosition(cameraPosition), duration, null);
+    }
+  }
+
   public void animateToCoordinate(LatLng coordinate, int duration) {
     if (map != null) {
       startMonitoringRegion();

--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -492,6 +492,14 @@ class MapView extends React.Component {
     this._runCommand('animateToCoordinate', [latLng, duration || 500]);
   }
 
+  animateToBearing(bearing, duration) {
+    this._runCommand('animateToBearing', [bearing, duration || 500]);
+  }
+
+  animateToViewingAngle(angle, duration) {
+    this._runCommand('animateToViewingAngle', [angle, duration || 500]);
+  }
+
   fitToElements(animated) {
     this._runCommand('fitToElements', [animated]);
   }

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
@@ -108,6 +108,42 @@ RCT_EXPORT_METHOD(animateToCoordinate:(nonnull NSNumber *)reactTag
   }];
 }
 
+RCT_EXPORT_METHOD(animateToViewingAngle:(nonnull NSNumber *)reactTag
+                  withAngle:(double)angle
+                  withDuration:(CGFloat)duration)
+{
+  [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+    id view = viewRegistry[reactTag];
+    if (![view isKindOfClass:[AIRGoogleMap class]]) {
+      RCTLogError(@"Invalid view returned from registry, expecting AIRGoogleMap, got: %@", view);
+    } else {
+      [CATransaction begin];
+      [CATransaction setAnimationDuration:duration/1000];
+      AIRGoogleMap *mapView = (AIRGoogleMap *)view;
+      [mapView animateToViewingAngle:angle];
+      [CATransaction commit];
+    }
+  }];
+}
+
+RCT_EXPORT_METHOD(animateToBearing:(nonnull NSNumber *)reactTag
+                  withBearing:(CGFloat)bearing
+                  withDuration:(CGFloat)duration)
+{
+  [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+    id view = viewRegistry[reactTag];
+    if (![view isKindOfClass:[AIRGoogleMap class]]) {
+      RCTLogError(@"Invalid view returned from registry, expecting AIRGoogleMap, got: %@", view);
+    } else {
+      [CATransaction begin];
+      [CATransaction setAnimationDuration:duration/1000];
+      AIRGoogleMap *mapView = (AIRGoogleMap *)view;
+      [mapView animateToBearing:bearing];
+      [CATransaction commit];
+    }
+  }];
+}
+
 RCT_EXPORT_METHOD(fitToElements:(nonnull NSNumber *)reactTag
                   animated:(BOOL)animated)
 {

--- a/lib/ios/AirMaps/AIRMapManager.m
+++ b/lib/ios/AirMaps/AIRMapManager.m
@@ -152,6 +152,48 @@ RCT_EXPORT_METHOD(animateToCoordinate:(nonnull NSNumber *)reactTag
     }];
 }
 
+RCT_EXPORT_METHOD(animateToViewingAngle:(nonnull NSNumber *)reactTag
+                  withAngle:(double)angle
+                  withDuration:(CGFloat)duration)
+{
+  [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+      id view = viewRegistry[reactTag];
+      if (![view isKindOfClass:[AIRMap class]]) {
+          RCTLogError(@"Invalid view returned from registry, expecting AIRMap, got: %@", view);
+      } else {
+          AIRMap *mapView = (AIRMap *)view;
+
+          MKMapCamera *mapCamera = [[mapView camera] copy];
+          [mapCamera setPitch:angle];
+
+          [AIRMap animateWithDuration:duration/1000 animations:^{
+              [mapView setCamera:mapCamera animated:YES];
+          }];
+      }
+  }];
+}
+
+RCT_EXPORT_METHOD(animateToBearing:(nonnull NSNumber *)reactTag
+                  withBearing:(CGFloat)bearing
+                  withDuration:(CGFloat)duration)
+{
+  [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+      id view = viewRegistry[reactTag];
+      if (![view isKindOfClass:[AIRMap class]]) {
+          RCTLogError(@"Invalid view returned from registry, expecting AIRMap, got: %@", view);
+      } else {
+          AIRMap *mapView = (AIRMap *)view;
+
+          MKMapCamera *mapCamera = [[mapView camera] copy];
+          [mapCamera setHeading:bearing];
+
+          [AIRMap animateWithDuration:duration/1000 animations:^{
+              [mapView setCamera:mapCamera animated:YES];
+          }];
+      }
+  }];
+}
+
 RCT_EXPORT_METHOD(fitToElements:(nonnull NSNumber *)reactTag
         animated:(BOOL)animated)
 {


### PR DESCRIPTION
First of all, thank you all guys for maintaining this awesome repo, it helps a lot to get started using Maps with ReactNative.

For those who are not familiar with the names of the functions this PR adds, Bearing is the direction or course of motion itself, and Viewing angle is the angle of the camera attached to the MapView.
This PR allows you to change the bearing dynamically (for example for apps that requires navigation features like Waze does) and also can change the map view angle (so you get like building shape kinda 3D).

~~This PR adds support for IOS (for now,  I plan to do for Android soon). I am pushing this so if anyone can help with feedback or code for Android I appreciate it 👍.~~
Updated: This PR adds full support for IOS (both native MapKit map and Google Maps) and Android.

Google Map Documentation for both methods is available here: https://developers.google.com/maps/documentation/ios-sdk/reference/interface_g_m_s_map_view.html#a5e59e999c9fa8222ecc8b9b45ce95976

I have no experience on Objective-C so they may be a better way of doing this, I just want to contribute trying to share something that worked for me :)

I attach a .gif trying to show the bearing effect (see how the map rotates towards the direction of motion), is hard to appreciate using a gif (it looks nice on real device when driving :)

![animatetobearing2-480](https://user-images.githubusercontent.com/466105/29201348-dc03ab02-7e33-11e7-8a4f-b55030ff395a.gif)