### PR TITLE
Fix initial region native prop

### DIFF
--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -450,7 +450,7 @@ class MapView extends React.Component {
     if (region) {
       this.map.setNativeProps({ region });
     } else if (initialRegion) {
-      this.map.setNativeProps({ region: initialRegion });
+      this.map.setNativeProps({ initialRegion });
     }
     this._updateStyle();
     this.setState({ isReady: true }, () => {

--- a/lib/ios/AirMaps/AIRMapManager.m
+++ b/lib/ios/AirMaps/AIRMapManager.m
@@ -665,7 +665,7 @@ static int kDragCenterContext;
 {
     [mapView finishLoading];
     [mapView cacheViewIfNeeded];
-    
+
     mapView.onMapReady(@{});
 }
 

--- a/lib/ios/AirMaps/AIRMapManager.m
+++ b/lib/ios/AirMaps/AIRMapManager.m
@@ -665,7 +665,7 @@ static int kDragCenterContext;
 {
     [mapView finishLoading];
     [mapView cacheViewIfNeeded];
-
+    
     mapView.onMapReady(@{});
 }
 


### PR DESCRIPTION
Fixes https://github.com/airbnb/react-native-maps/issues/1540 and https://github.com/airbnb/react-native-maps/issues/1507.

Sometimes it could happen that, when using initialRegion prop and moving on the map, we could just come back to our initial region for no reason. That's because we never set the initialRegion prop in the native code, but we set the region prop, while our component has the initialRegion prop.