### PR TITLE
Fixed `Archive` configuration for iOS

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -36,5 +36,9 @@ post_install do |installer|
         config.build_settings['CLANG_ENABLE_MODULES'] = 'No'
       end
     end
+    
+    if target.name == "React"
+      target.remove_from_project
+    end
   end
 end


### PR DESCRIPTION
Remove `React` target from `Pods` xcproject.

As seen in https://github.com/facebook/react-native/issues/12814