### PR TITLE
Add support to set map boundaries

### DIFF
--- a/docs/mapview.md
+++ b/docs/mapview.md
@@ -64,6 +64,7 @@ To access event data, you will need to use `e.nativeEvent`. For example, `onPres
 |---|---|---|
 | `animateToRegion` | `region: Region`, `duration: Number` |
 | `animateToCoordinate` | `coordinate: LatLng`, `duration: Number` |
+| `setMapBoundaries` | `northEast: LatLng`, `southWest: LatLng` |
 | `fitToElements` | `animated: Boolean` |
 | `fitToSuppliedMarkers` | `markerIDs: String[]`, `animated: Boolean` | If you need to use this in `ComponentDidMount`, make sure you put it in a timeout or it will cause performance problems.
 | `fitToCoordinates` | `coordinates: Array<LatLng>, options: { edgePadding: EdgePadding, animated: Boolean }` | If called in `ComponentDidMount` in android, it will cause an exception. It is recommended to call it from the MapView `onLayout` event.

--- a/docs/mapview.md
+++ b/docs/mapview.md
@@ -64,7 +64,7 @@ To access event data, you will need to use `e.nativeEvent`. For example, `onPres
 |---|---|---|
 | `animateToRegion` | `region: Region`, `duration: Number` |
 | `animateToCoordinate` | `coordinate: LatLng`, `duration: Number` |
-| `setMapBoundaries` | `northEast: LatLng`, `southWest: LatLng` |
+| `setMapBoundaries` | `northEast: LatLng`, `southWest: LatLng` | `GoogleMaps only`
 | `fitToElements` | `animated: Boolean` |
 | `fitToSuppliedMarkers` | `markerIDs: String[]`, `animated: Boolean` | If you need to use this in `ComponentDidMount`, make sure you put it in a timeout or it will cause performance problems.
 | `fitToCoordinates` | `coordinates: Array<LatLng>, options: { edgePadding: EdgePadding, animated: Boolean }` | If called in `ComponentDidMount` in android, it will cause an exception. It is recommended to call it from the MapView `onLayout` event.

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
@@ -32,6 +32,7 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
   private static final int FIT_TO_ELEMENTS = 3;
   private static final int FIT_TO_SUPPLIED_MARKERS = 4;
   private static final int FIT_TO_COORDINATES = 5;
+  private static final int SET_MAP_BOUNDARIES = 6;
 
   private final Map<String, Integer> MAP_TYPES = MapBuilder.of(
       "standard", GoogleMap.MAP_TYPE_NORMAL,
@@ -232,8 +233,13 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
       case FIT_TO_SUPPLIED_MARKERS:
         view.fitToSuppliedMarkers(args.getArray(0), args.getBoolean(1));
         break;
+
       case FIT_TO_COORDINATES:
         view.fitToCoordinates(args.getArray(0), args.getMap(1), args.getBoolean(2));
+        break;
+
+      case SET_MAP_BOUNDARIES:
+        view.setMapBoundaries(args.getMap(0), args.getMap(1));
         break;
     }
   }
@@ -269,7 +275,8 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
         "animateToCoordinate", ANIMATE_TO_COORDINATE,
         "fitToElements", FIT_TO_ELEMENTS,
         "fitToSuppliedMarkers", FIT_TO_SUPPLIED_MARKERS,
-        "fitToCoordinates", FIT_TO_COORDINATES
+        "fitToCoordinates", FIT_TO_COORDINATES,
+        "setMapBoundaries", SET_MAP_BOUNDARIES
     );
   }
 

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -666,6 +666,24 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
         0); // Without this, the Google logo is moved up by the value of edgePadding.bottom
   }
 
+  public void setMapBoundaries(ReadableMap northEast, ReadableMap southWest) {
+    LatLngBounds.Builder builder = new LatLngBounds.Builder();
+
+    Double latNE = northEast.getDouble("latitude");
+    Double lngNE = northEast.getDouble("longitude");
+    builder.include(new LatLng(latNE, lngNE));
+
+    Double latSW = southWest.getDouble("latitude");
+    Double lngSW = southWest.getDouble("longitude");
+    builder.include(new LatLng(latSW, lngSW));
+
+    LatLngBounds bounds = builder.build();
+
+    if (map != null) {
+      map.setLatLngBoundsForCameraTarget(bounds);
+    }
+  }
+
   // InfoWindowAdapter interface
 
   @Override

--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -512,6 +512,10 @@ class MapView extends React.Component {
     this._runCommand('fitToCoordinates', [coordinates, edgePadding, animated]);
   }
 
+  setMapBoundaries(northEast, southWest) {
+    this._runCommand('setMapBoundaries', [northEast, southWest]);
+  }
+
   /**
    * Takes a snapshot of the map and saves it to a picture
    * file or returns the image as a base64 encoded string.

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
@@ -222,6 +222,24 @@ RCT_EXPORT_METHOD(takeSnapshot:(nonnull NSNumber *)reactTag
   }];
 }
 
+RCT_EXPORT_METHOD(setMapBoundaries:(nonnull NSNumber *)reactTag
+                  northEast:(CLLocationCoordinate2D)northEast
+                  southWest:(CLLocationCoordinate2D)southWest)
+{
+  [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+    id view = viewRegistry[reactTag];
+    if (![view isKindOfClass:[AIRGoogleMap class]]) {
+      RCTLogError(@"Invalid view returned from registry, expecting AIRGoogleMap, got: %@", view);
+    } else {
+      AIRGoogleMap *mapView = (AIRGoogleMap *)view;
+
+      GMSCoordinateBounds *bounds = [[GMSCoordinateBounds alloc] initWithCoordinate:northEast coordinate:southWest];
+
+      mapView.cameraTargetBounds = bounds;
+    }
+  }];
+}
+
 - (NSDictionary *)constantsToExport {
   return @{ @"legalNotice": [GMSServices openSourceLicenseInfo] };
 }


### PR DESCRIPTION
![bound_example_ios](https://user-images.githubusercontent.com/10161117/29624563-64364dd2-87f7-11e7-9093-cba5e384aa3c.gif)
![bound_example_android](https://user-images.githubusercontent.com/10161117/29624568-67cdebc6-87f7-11e7-8d82-db3b6033feca.gif)



Adds the ability to prevent scrolling outside of a set of boundary coordinates. Pass in two `LatLng` points, preferably a North East point and a South West point (In testing any two points worked and the overlapping area formed the desired region).

- Works on Android and Google Maps for iOS
- Solves #1424  (my issue 🎉 ) 
- [Android Docs](https://developers.google.com/maps/documentation/android-api/views#restricting_the_users_panning_to_a_given_area)
- [iOS Docs](https://developers.google.com/maps/documentation/ios-sdk/reference/interface_g_m_s_map_view.html#af18afcf5b4eab9edf2b700734d2c7f07)