### PR TITLE
Remove legalNotice from android AirMapModule

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapModule.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapModule.java
@@ -47,7 +47,7 @@ public class AirMapModule extends ReactContextBaseJavaModule {
   @Override
   public Map<String, Object> getConstants() {
     final Map<String, Object> constants = new HashMap<>();
-    constants.put("legalNotice", GoogleApiAvailability.getInstance().getOpenSourceSoftwareLicenseInfo(getReactApplicationContext()));
+    constants.put("legalNotice", "This license information is displayed in Settings > Google > Open Source on any device running Google Play services.");
     return constants;
   }
 


### PR DESCRIPTION
As per https://developers.google.com/android/reference/com/google/android/gms/common/GooglePlayServicesUtil#getOpenSourceSoftwareLicenseInfo(android.content.Context) this information does not need to be displayed in app.