### PR TITLE
[MapView] revert initialRegion change

### DIFF
--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -466,13 +466,10 @@ class MapView extends React.Component {
     const { layout } = e.nativeEvent;
     if (!layout.width || !layout.height) return;
     if (this.state.isReady && !this.__layoutCalled) {
-      const { region, initialRegion } = this.props;
+      const region = this.props.region || this.props.initialRegion;
       if (region) {
         this.__layoutCalled = true;
         this.map.setNativeProps({ region });
-      } else if (initialRegion) {
-        this.__layoutCalled = true;
-        this.map.setNativeProps({ initialRegion });
       }
     }
     if (this.props.onLayout) {


### PR DESCRIPTION
Reverts JS changes made in #1563 which broke initialRegion on iOS,
causing the map to display a region centered around 0, 0.