### PR TITLE
[BUGFIX] Add condition to use getOpenSourceSoftwareLicenseInfo

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapModule.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapModule.java
@@ -47,7 +47,12 @@ public class AirMapModule extends ReactContextBaseJavaModule {
   @Override
   public Map<String, Object> getConstants() {
     final Map<String, Object> constants = new HashMap<>();
-    constants.put("legalNotice", GoogleApiAvailability.getInstance().getOpenSourceSoftwareLicenseInfo(getReactApplicationContext()));
+    try {
+      constants.put("legalNotice", GoogleApiAvailability.getInstance().getOpenSourceSoftwareLicenseInfo(getReactApplicationContext()));
+    } catch (Exception e) {
+      constants.put("legalNotice", "");
+      Log.i("ReactMaps", "getOpenSourceSoftwareLicenseInfo is not available: " + e.getMessage());
+    }
     return constants;
   }
 

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapModule.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapModule.java
@@ -5,7 +5,6 @@ import android.graphics.Bitmap;
 import android.net.Uri;
 import android.util.Base64;
 import android.util.DisplayMetrics;
-import android.util.Log;
 
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapModule.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapModule.java
@@ -35,6 +35,7 @@ public class AirMapModule extends ReactContextBaseJavaModule {
   private static final String SNAPSHOT_RESULT_BASE64 = "base64";
   private static final String SNAPSHOT_FORMAT_PNG = "png";
   private static final String SNAPSHOT_FORMAT_JPG = "jpg";
+  private static final Integer GOOGLE_PLAY_SERVICES_VERSION_CODE_11 = 11000000;
 
   public AirMapModule(ReactApplicationContext reactContext) {
     super(reactContext);
@@ -48,12 +49,17 @@ public class AirMapModule extends ReactContextBaseJavaModule {
   @Override
   public Map<String, Object> getConstants() {
     final Map<String, Object> constants = new HashMap<>();
-    try {
-      constants.put("legalNotice", GoogleApiAvailability.getInstance().getOpenSourceSoftwareLicenseInfo(getReactApplicationContext()));
-    } catch (Exception e) {
-      constants.put("legalNotice", "");
-      Log.i("ReactMaps", "getOpenSourceSoftwareLicenseInfo is not available: " + e.getMessage());
+
+    // The function getOpenSourceSoftwareLicenseInfo has been removed in GooglePlayServices version 11
+    if (GoogleApiAvailability.GOOGLE_PLAY_SERVICES_VERSION_CODE < GOOGLE_PLAY_SERVICES_VERSION_CODE_11) {
+      constants.put(
+        "legalNotice",
+        GoogleApiAvailability
+          .getInstance()
+          .getOpenSourceSoftwareLicenseInfo(getReactApplicationContext())
+      );
     }
+
     return constants;
   }
 

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapModule.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapModule.java
@@ -5,6 +5,7 @@ import android.graphics.Bitmap;
 import android.net.Uri;
 import android.util.Base64;
 import android.util.DisplayMetrics;
+import android.util.Log;
 
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;


### PR DESCRIPTION
The getOpenSourceSoftwareLicenseInfo function has been deprecated
for Google Play-Services since version 11 and leads to problems.

> getOpenSourceSoftwareLicenseInfo(Context context)
> This method was deprecated. This license information is displayed in Settings > Google > Open
Source on any device running Google Play services. Applications do not need to display this license text, and this method will be removed in a future version of Google Play services.

Therefore we should check if the GoogleApiAvailability let us get the
license information.

Fixes #1625