### PR TITLE
[MapMarker] fix android release crash on custom marker

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapMarker.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapMarker.java
@@ -2,6 +2,7 @@ package com.airbnb.android.react.maps;
 
 import android.content.Context;
 import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 import android.graphics.Canvas;
 import android.graphics.drawable.Animatable;
 import android.net.Uri;
@@ -236,6 +237,9 @@ public class AirMapMarker extends AirMapFeature {
       logoHolder.setController(controller);
     } else {
       iconBitmapDescriptor = getBitmapDescriptorByName(uri);
+      if (iconBitmapDescriptor != null) {
+          iconBitmap = BitmapFactory.decodeResource(getResources(), getDrawableResourceByName(uri));
+      }
       update();
     }
   }


### PR DESCRIPTION
Fixes an error on Android release mode when the Map.Marker has children.
```
java.lang.NullPointerException: Attempt to invoke virtual method 'int android.graphics.Bitmap.getWidth()' on a null object reference
```

From https://github.com/Geor23/react-native-maps/commit/a83c04a4ebb1697e17cf2e77a2f26e9142ea5cc7
Closes https://github.com/airbnb/react-native-maps/issues/907