### PR TITLE
Remove legalNotice constant (#1571)

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapModule.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapModule.java
@@ -44,13 +44,6 @@ public class AirMapModule extends ReactContextBaseJavaModule {
     return "AirMapModule";
   }
 
-  @Override
-  public Map<String, Object> getConstants() {
-    final Map<String, Object> constants = new HashMap<>();
-    constants.put("legalNotice", GoogleApiAvailability.getInstance().getOpenSourceSoftwareLicenseInfo(getReactApplicationContext()));
-    return constants;
-  }
-
   public Activity getActivity() {
     return getCurrentActivity();
   }


### PR DESCRIPTION
As mentioned in the bug report, [this is deprecated and no longer needed](https://developers.google.com/android/reference/com/google/android/gms/common/GooglePlayServicesUtil#getOpenSourceSoftwareLicenseInfo(android.content.Context)).