### PR TITLE
Add customPadding prop

### DIFF
--- a/ios/AirGoogleMaps/AIRGoogleMap.h
+++ b/ios/AirGoogleMaps/AIRGoogleMap.h
@@ -14,6 +14,7 @@
 
 @interface AIRGoogleMap : GMSMapView
 
+@property (nonatomic, assign) UIEdgeInsets customPadding;
 // TODO: don't use MK region?
 @property (nonatomic, assign) MKCoordinateRegion initialRegion;
 @property (nonatomic, assign) MKCoordinateRegion region;

--- a/ios/AirGoogleMaps/AIRGoogleMap.m
+++ b/ios/AirGoogleMaps/AIRGoogleMap.m
@@ -134,6 +134,10 @@ id regionAsJSON(MKCoordinateRegion region) {
 }
 #pragma clang diagnostic pop
 
+- (void)setCustomPadding(UIEdgeInsets)customPadding {
+  self.padding = customPadding;
+}
+
 - (void)setInitialRegion:(MKCoordinateRegion)initialRegion {
   if (_initialRegionSet) return;
   _initialRegionSet = true;

--- a/ios/AirGoogleMaps/AIRGoogleMapManager.m
+++ b/ios/AirGoogleMaps/AIRGoogleMapManager.m
@@ -45,6 +45,7 @@ RCT_EXPORT_MODULE()
   return map;
 }
 
+RCT_EXPORT_VIEW_PROPERTY(customPadding, UIEdgeInsets)
 RCT_EXPORT_VIEW_PROPERTY(initialRegion, MKCoordinateRegion)
 RCT_EXPORT_VIEW_PROPERTY(region, MKCoordinateRegion)
 RCT_EXPORT_VIEW_PROPERTY(showsBuildings, BOOL)


### PR DESCRIPTION
We need to be able to set the `padding` attribute of the native maps for both iOS and Android however `padding` is a reserved prop name so I've added this as `customPadding`. 