### PR TITLE
Added support for new Android camera movement APIs

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/maps/RegionChangeEvent.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/RegionChangeEvent.java
@@ -9,13 +9,11 @@ import com.google.android.gms.maps.model.LatLngBounds;
 
 public class RegionChangeEvent extends Event<RegionChangeEvent> {
   private final LatLngBounds bounds;
-  private final LatLng center;
   private final boolean continuous;
 
-  public RegionChangeEvent(int id, LatLngBounds bounds, LatLng center, boolean continuous) {
+  public RegionChangeEvent(int id, LatLngBounds bounds, boolean continuous) {
     super(id);
     this.bounds = bounds;
-    this.center = center;
     this.continuous = continuous;
   }
 
@@ -36,6 +34,7 @@ public class RegionChangeEvent extends Event<RegionChangeEvent> {
     event.putBoolean("continuous", continuous);
 
     WritableMap region = new WritableNativeMap();
+    LatLng center = bounds.getCenter();
     region.putDouble("latitude", center.latitude);
     region.putDouble("longitude", center.longitude);
     region.putDouble("latitudeDelta", bounds.northeast.latitude - bounds.southwest.latitude);


### PR DESCRIPTION
`OnCameraChangeListener` is deprecated and should no longer be used. This PR adds support for the new more powerful APIs and removes the old (quite hacky..) region detection code. This fixes various issues and paves the way for distinguishing between gestures and manual/programatic animations at the same time.

![image](https://user-images.githubusercontent.com/6184593/31687121-a75a2388-b388-11e7-8902-fb29fa4b19ba.png)
https://developers.google.com/android/reference/com/google/android/gms/maps/GoogleMap.OnCameraChangeListener

This PR fixes #1709 and I'm pretty sure it also fixes:
- #349
- #1379 
- #1591 
- #134 
- #846 
- #459
