### PR TITLE
Workaround for "GoogleMapsBase not found" issue

### DIFF
--- a/react-native-google-maps.podspec
+++ b/react-native-google-maps.podspec
@@ -14,6 +14,7 @@ Pod::Spec.new do |s|
 
   s.source       = { :git => "https://github.com/airbnb/react-native-maps.git" }
   s.source_files  = "lib/ios/AirGoogleMaps/**/*.{h,m}"
+  s.compiler_flags = '-fno-modules'
 
   s.dependency 'React'
   s.dependency 'GoogleMaps', '2.1.1'


### PR DESCRIPTION
XCode 9 together with RN 0.49.1 throws the error that GoogleMapsBase could not be found. This PR introduces a workaround based on this PR: https://github.com/googlemaps/google-maps-ios-utils/pull/20/files

Fixes issue #990 and #1722 