### PR TITLE
Fix React Native 0.49 requiresMainQueueSetup

### DIFF
--- a/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
@@ -263,6 +263,10 @@ RCT_EXPORT_METHOD(takeSnapshot:(nonnull NSNumber *)reactTag
   return @{ @"legalNotice": [GMSServices openSourceLicenseInfo] };
 }
 
++ (BOOL)requiresMainQueueSetup {
+  return YES;
+}
+
 - (void)mapViewDidFinishTileRendering:(GMSMapView *)mapView {
     AIRGoogleMap *googleMapView = (AIRGoogleMap *)mapView;
     [googleMapView didFinishTileRendering];


### PR DESCRIPTION
Fixes Warning for react-native > 0.49

> Module AIRGoogleMapManager requires main queue setup since it overrides `constantsToExport` but doesn't implement `requiresMainQueueSetup. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.