### PR TITLE
Fixes issue running on ReactNative 0.42.3 - 'MapMarker' has no propType for native prop 'AIRMapMarker.testId' of native type 'String'

### DIFF
--- a/lib/components/MapMarker.js
+++ b/lib/components/MapMarker.js
@@ -7,6 +7,7 @@ import {
   Animated,
   findNodeHandle,
   ViewPropTypes,
+  View
 } from 'react-native';
 
 import resolveAssetSource from 'react-native/Libraries/Image/resolveAssetSource';
@@ -24,6 +25,7 @@ const viewConfig = {
 
 const propTypes = {
   ...ViewPropTypes,
+  ...View.propTypes,
 
   // TODO(lmr): get rid of these?
   identifier: PropTypes.string,


### PR DESCRIPTION
If you've been running into the dreaded `MapMarker has no propType for native prop AIRMapMarker.testID of native type String` or something similar, this is the fix! Two lines!

Closes #1650 
Closes #1532 
Closes #1656 
