### PR TITLE
Fixed onMapReady event on iOS to resemble onMapReady on Android

### DIFF
--- a/lib/ios/AirGoogleMaps/AIRGoogleMap.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMap.h
@@ -42,7 +42,7 @@
 @property (nonatomic, assign) BOOL showsMyLocationButton;
 @property (nonatomic, assign) BOOL showsIndoorLevelPicker;
 
-- (void)didFinishTileRendering;
+- (void)didPrepareMap;
 - (BOOL)didTapMarker:(GMSMarker *)marker;
 - (void)didTapPolyline:(GMSPolyline *)polyline;
 - (void)didTapPolygon:(GMSPolygon *)polygon;

--- a/lib/ios/AirGoogleMaps/AIRGoogleMap.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMap.m
@@ -155,7 +155,7 @@ id regionAsJSON(MKCoordinateRegion region) {
   self.camera = [AIRGoogleMap makeGMSCameraPositionFromMap:self  andMKCoordinateRegion:region];
 }
 
-- (void)didFinishTileRendering {
+- (void)didPrepareMap {
     if (self.onMapReady) self.onMapReady(@{});
 }
 

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
@@ -32,7 +32,10 @@ static NSString *const RCTMapViewKey = @"MapView";
 
 
 @interface AIRGoogleMapManager() <GMSMapViewDelegate>
-
+{
+  BOOL didCallOnMapReady;
+}
+  
 @end
 
 @implementation AIRGoogleMapManager
@@ -263,13 +266,12 @@ RCT_EXPORT_METHOD(takeSnapshot:(nonnull NSNumber *)reactTag
   return @{ @"legalNotice": [GMSServices openSourceLicenseInfo] };
 }
 
-+ (BOOL)requiresMainQueueSetup {
-  return YES;
-}
-
-- (void)mapViewDidFinishTileRendering:(GMSMapView *)mapView {
-    AIRGoogleMap *googleMapView = (AIRGoogleMap *)mapView;
-    [googleMapView didFinishTileRendering];
+- (void)mapViewDidStartTileRendering:(GMSMapView *)mapView {
+  if (didCallOnMapReady) return;
+  didCallOnMapReady = YES;
+  
+  AIRGoogleMap *googleMapView = (AIRGoogleMap *)mapView;
+  [googleMapView didPrepareMap];
 }
 
 - (BOOL)mapView:(GMSMapView *)mapView didTapMarker:(GMSMarker *)marker {

--- a/lib/ios/AirMaps/AIRMapManager.m
+++ b/lib/ios/AirMaps/AIRMapManager.m
@@ -36,7 +36,10 @@ static NSString *const RCTMapViewKey = @"MapView";
 @end
 
 @implementation AIRMapManager
-
+{
+    BOOL didCallOnMapReady;
+}
+  
 RCT_EXPORT_MODULE()
 
 - (UIView *)view
@@ -708,6 +711,12 @@ static int kDragCenterContext;
 
 - (void)mapViewWillStartRenderingMap:(AIRMap *)mapView
 {
+    if (!didCallOnMapReady)
+    {
+      didCallOnMapReady = YES;
+      mapView.onMapReady(@{});
+    }
+  
     mapView.hasStartedRendering = YES;
     [mapView beginLoading];
     [self _emitRegionChangeEvent:mapView continuous:NO];
@@ -716,9 +725,6 @@ static int kDragCenterContext;
 - (void)mapViewDidFinishRenderingMap:(AIRMap *)mapView fullyRendered:(BOOL)fullyRendered
 {
     [mapView finishLoading];
-    [mapView cacheViewIfNeeded];
-
-    mapView.onMapReady(@{});
 }
 
 #pragma mark Private


### PR DESCRIPTION
(Closes #1793)

Also: Closes #1776, Closes #1696, Closes #1680, Closes #1605)
Probably closes more issues related to iOS, panning and scrolling.

---

The issue is that on Android, the onMapReady comes from the native onMapReady event, which occurs when Google Play Services first provides a Google Maps view.

But on iOS - it happened whenever rendering has finished - which is a completely different interpretation, and misses the point of just doing the initial stuff like `initialRegion`/`region`.