### PR TITLE
Allow fitToCoordinates to be called without options parameter

### DIFF
--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -515,7 +515,7 @@ class MapView extends React.Component {
     this._runCommand('fitToSuppliedMarkers', [markers, animated]);
   }
 
-  fitToCoordinates(coordinates = [], options) {
+  fitToCoordinates(coordinates = [], options = {}) {
     const {
       edgePadding = { top: 0, right: 0, bottom: 0, left: 0 },
       animated = true,


### PR DESCRIPTION
Right now it's not possible to call `fitToCoordinates` without an `options` parameter, even though defaults are defined in the function body.

This commit set the default value of the `options` parameter of  to an empty object, allowing one to call the function without it _(and with respect for the defaults)_.